### PR TITLE
Fix links that doesn't point to latest version

### DIFF
--- a/src/main/templates/footer.html
+++ b/src/main/templates/footer.html
@@ -5,7 +5,7 @@
         <h2>Vert.x</h2>
         <ul class="list-unstyled">
           <li><a href="{{ site_url }}">Home</a></li>
-          <li><a href="https://bintray.com/vertx/downloads/distribution/view">Download</a></li>
+          <li><a href="https://bintray.com/vertx/downloads/distribution/3.0.0/view">Download</a></li>
           <li><a href="{{ site_url }}docs/">Documentation</a></li>
           <li><a href="https://github.com/vert-x3/wiki/wiki">Wiki</a></li>
           <li><a href="{{ site_url }}blog/">Blog</a></li>

--- a/src/main/templates/header.html
+++ b/src/main/templates/header.html
@@ -49,7 +49,7 @@
     <nav class="collapse navbar-collapse" id="vertx-navbar-collapse">
       <ul class="nav navbar-nav navbar-right">
         <!--<li class=""><a href="vertx-home.html">HOME</a></li>-->
-        <li><a href="https://bintray.com/vertx/downloads/distribution/view">Download</a></li>
+        <li><a href="https://bintray.com/vertx/downloads/distribution/3.0.0/view">Download</a></li>
         <li><a href="{{ site_url }}docs/">Documentation</a></li>
         <li><a href="https://github.com/vert-x3/wiki/wiki">Wiki</a></li>
         <li><a href="{{ site_url }}community/">Community</a></li>


### PR DESCRIPTION
A colleague expent more time that he'll ever be willing to accept navigating in "vertx-2" examples...
When I started "friendly" laughing at him for not being able to follow a proper link from http://vertx.io, he showed me that some the "Download" link both in header and footer were pointing to de 2.1.6 version in bintray.

So... somebody should update bintray to show the latest version by default, but anyway fixing the links is not a bad idea, imho.