### PR TITLE
sort contributor list by githubid to avoid superfluous changes when regenerating the list

### DIFF
--- a/src-gen/main/community/contributors-gen.js
+++ b/src-gen/main/community/contributors-gen.js
@@ -1,557 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT! CALL `gulp update-contributors` INSTEAD.
-// CREATED: Wed Jun 24 2015 09:02:38 GMT+0100 (BST)
+// CREATED: Sun Oct 04 2015 15:16:26 GMT+0200 (Mitteleuropäische Sommerzeit)
 module.exports = { contributors: [
-  {
-    "github_id": "normanmaurer",
-    "avatar": "https://avatars.githubusercontent.com/u/439362?v=3&s=80",
-    "github": "https://github.com/normanmaurer",
-    "name": "Norman Maurer",
-    "homepage": "http://normanmaurer.me"
-  },
-  {
-    "github_id": "nscavell",
-    "avatar": "https://avatars.githubusercontent.com/u/447664?v=3&s=80",
-    "github": "https://github.com/nscavell",
-    "name": "Nick Scavelli"
-  },
-  {
-    "github_id": "alexlehm",
-    "avatar": "https://avatars.githubusercontent.com/u/156144?v=3&s=80",
-    "github": "https://github.com/alexlehm",
-    "name": "Alexander Lehmann",
-    "homepage": "http://about.me/alexlehm"
-  },
-  {
-    "github_id": "gitplaneta",
-    "avatar": "https://avatars.githubusercontent.com/u/2615595?v=3&s=80",
-    "github": "https://github.com/gitplaneta",
-    "name": "Radosław Busz",
-    "homepage": "https://twitter.com/radekbusz"
-  },
-  {
-    "github_id": "MammatusPlatypus",
-    "avatar": "https://avatars.githubusercontent.com/u/643140?v=3&s=80",
-    "github": "https://github.com/MammatusPlatypus",
-    "name": "MammatusPlatypus"
-  },
-  {
-    "github_id": "adrianluisgonzalez",
-    "avatar": "https://avatars.githubusercontent.com/u/1521539?v=3&s=80",
-    "github": "https://github.com/adrianluisgonzalez",
-    "name": "Adrian"
-  },
-  {
-    "github_id": "larrytin",
-    "avatar": "https://avatars.githubusercontent.com/u/4640250?v=3&s=80",
-    "github": "https://github.com/larrytin",
-    "name": "田传武"
-  },
-  {
-    "github_id": "wprice",
-    "avatar": "https://avatars.githubusercontent.com/u/467370?v=3&s=80",
-    "github": "https://github.com/wprice",
-    "name": "Weston M. Price",
-    "homepage": "http://www.redhat.com/en"
-  },
-  {
-    "github_id": "lance",
-    "avatar": "https://avatars.githubusercontent.com/u/15952?v=3&s=80",
-    "github": "https://github.com/lance",
-    "name": "Lance Ball",
-    "homepage": "http://lanceball.com"
-  },
-  {
-    "github_id": "rexorient",
-    "avatar": "https://avatars.githubusercontent.com/u/3493024?v=3&s=80",
-    "github": "https://github.com/rexorient",
-    "name": "rexorient"
-  },
-  {
-    "github_id": "p14n",
-    "avatar": "https://avatars.githubusercontent.com/u/676545?v=3&s=80",
-    "github": "https://github.com/p14n",
-    "name": "Dean Pehrsson-Chapman",
-    "homepage": "http://www.p14n.com"
-  },
-  {
-    "github_id": "tobias",
-    "avatar": "https://avatars.githubusercontent.com/u/2631?v=3&s=80",
-    "github": "https://github.com/tobias",
-    "name": "Toby Crawley",
-    "homepage": "http://tcrawley.org/"
-  },
-  {
-    "github_id": "heri333",
-    "avatar": "https://avatars.githubusercontent.com/u/1039538?v=3&s=80",
-    "github": "https://github.com/heri333",
-    "name": "Heribert Hirth"
-  },
-  {
-    "github_id": "hgschmie",
-    "avatar": "https://avatars.githubusercontent.com/u/39495?v=3&s=80",
-    "github": "https://github.com/hgschmie",
-    "name": "Henning Schmiedehausen",
-    "homepage": "http://about.me/hgschmie"
-  },
-  {
-    "github_id": "LostInBrittany",
-    "avatar": "https://avatars.githubusercontent.com/u/726476?v=3&s=80",
-    "github": "https://github.com/LostInBrittany",
-    "name": "Horacio Gonzalez",
-    "homepage": "http://lostinbrittany.org"
-  },
-  {
-    "github_id": "jtruelove",
-    "avatar": "https://avatars.githubusercontent.com/u/633168?v=3&s=80",
-    "github": "https://github.com/jtruelove",
-    "name": "Jeremy Truelove"
-  },
-  {
-    "github_id": "beders",
-    "avatar": "https://avatars.githubusercontent.com/u/522318?v=3&s=80",
-    "github": "https://github.com/beders",
-    "name": "Jochen Bedersdorfer"
-  },
-  {
-    "github_id": "johnoliver",
-    "avatar": "https://avatars.githubusercontent.com/u/1615532?v=3&s=80",
-    "github": "https://github.com/johnoliver",
-    "name": "John Oliver"
-  },
-  {
-    "github_id": "kuujo",
-    "avatar": "https://avatars.githubusercontent.com/u/823318?v=3&s=80",
-    "github": "https://github.com/kuujo",
-    "name": "Jordan Halterman"
-  },
-  {
-    "github_id": "zdanek",
-    "avatar": "https://avatars.githubusercontent.com/u/440614?v=3&s=80",
-    "github": "https://github.com/zdanek",
-    "name": "Bartek Zdanowski",
-    "homepage": "http://bartekzdanowski.blogspot.com/"
-  },
-  {
-    "github_id": "sibay",
-    "avatar": "https://avatars.githubusercontent.com/u/12139958?v=3&s=80",
-    "github": "https://github.com/sibay",
-    "name": "Tarek El-Sibay"
-  },
-  {
-    "github_id": "LarsTimm",
-    "avatar": "https://avatars.githubusercontent.com/u/12085953?v=3&s=80",
-    "github": "https://github.com/LarsTimm",
-    "name": "Lars Timm"
-  },
-  {
-    "github_id": "ALRubinger",
-    "avatar": "https://avatars.githubusercontent.com/u/199891?v=3&s=80",
-    "github": "https://github.com/ALRubinger",
-    "name": "Andrew Lee Rubinger",
-    "homepage": "http://exitcondition.alrubinger.com"
-  },
-  {
-    "github_id": "bura",
-    "avatar": "https://avatars.githubusercontent.com/u/1369932?v=3&s=80",
-    "github": "https://github.com/bura",
-    "name": "Andrey Bloschetsov"
-  },
-  {
-    "github_id": "aesteve",
-    "avatar": "https://avatars.githubusercontent.com/u/1456317?v=3&s=80",
-    "github": "https://github.com/aesteve",
-    "name": "Arnaud Esteve"
-  },
-  {
-    "github_id": "catandgrep",
-    "avatar": "https://avatars.githubusercontent.com/u/1639457?v=3&s=80",
-    "github": "https://github.com/catandgrep",
-    "name": "Andreas"
-  },
-  {
-    "github_id": "dankraw",
-    "avatar": "https://avatars.githubusercontent.com/u/2399036?v=3&s=80",
-    "github": "https://github.com/dankraw",
-    "name": "Daniel Krawczyk"
-  },
-  {
-    "github_id": "ddossot",
-    "avatar": "https://avatars.githubusercontent.com/u/119028?v=3&s=80",
-    "github": "https://github.com/ddossot",
-    "name": "David Dossot",
-    "homepage": "http://david.dossot.net"
-  },
-  {
-    "github_id": "fmatar",
-    "avatar": "https://avatars.githubusercontent.com/u/111766?v=3&s=80",
-    "github": "https://github.com/fmatar",
-    "name": "Fady Matar"
-  },
-  {
-    "github_id": "Narigo",
-    "avatar": "https://avatars.githubusercontent.com/u/1767865?v=3&s=80",
-    "github": "https://github.com/Narigo",
-    "name": "Joern Bernhardt",
-    "homepage": "http://www.campudus.com/"
-  },
-  {
-    "github_id": "jarthorn",
-    "avatar": "https://avatars.githubusercontent.com/u/193877?v=3&s=80",
-    "github": "https://github.com/jarthorn",
-    "name": "John Arthorne"
-  },
-  {
-    "github_id": "jkeys089",
-    "avatar": "https://avatars.githubusercontent.com/u/1695857?v=3&s=80",
-    "github": "https://github.com/jkeys089",
-    "name": "jkeys089"
-  },
-  {
-    "github_id": "gaol",
-    "avatar": "https://avatars.githubusercontent.com/u/541437?v=3&s=80",
-    "github": "https://github.com/gaol",
-    "name": "Lin Gao",
-    "homepage": "http://www.ironjacamar.org"
-  },
-  {
-    "github_id": "pdalpra",
-    "avatar": "https://avatars.githubusercontent.com/u/1514127?v=3&s=80",
-    "github": "https://github.com/pdalpra",
-    "name": "Pierre Dal-Pra"
-  },
-  {
-    "github_id": "pwielgolaski",
-    "avatar": "https://avatars.githubusercontent.com/u/3696319?v=3&s=80",
-    "github": "https://github.com/pwielgolaski",
-    "name": "Piotr Wielgolaski"
-  },
-  {
-    "github_id": "RichardHightower",
-    "avatar": "https://avatars.githubusercontent.com/u/382678?v=3&s=80",
-    "github": "https://github.com/RichardHightower",
-    "name": "Richard Hightower",
-    "homepage": "http://rick-hightower.blogspot.com/"
-  },
-  {
-    "github_id": "ruslansennov",
-    "avatar": "https://avatars.githubusercontent.com/u/1582377?v=3&s=80",
-    "github": "https://github.com/ruslansennov",
-    "name": "Ruslan Sennov",
-    "homepage": "http://ruslan-sennov.blogspot.com/"
-  },
-  {
-    "github_id": "zaytsev",
-    "avatar": "https://avatars.githubusercontent.com/u/182761?v=3&s=80",
-    "github": "https://github.com/zaytsev",
-    "name": "Sergey Zaytsev"
-  },
-  {
-    "github_id": "darylteo",
-    "avatar": "https://avatars.githubusercontent.com/u/1226920?v=3&s=80",
-    "github": "https://github.com/darylteo",
-    "name": "Daryl Teo",
-    "homepage": "http://darylteo.com"
-  },
-  {
-    "github_id": "denisroy",
-    "avatar": "https://avatars.githubusercontent.com/u/2522829?v=3&s=80",
-    "github": "https://github.com/denisroy",
-    "name": "denisroy"
-  },
-  {
-    "github_id": "megesdal",
-    "avatar": "https://avatars.githubusercontent.com/u/772686?v=3&s=80",
-    "github": "https://github.com/megesdal",
-    "name": "Mark Egesdal",
-    "homepage": "http://outsideiq.com"
-  },
-  {
-    "github_id": "thmarx",
-    "avatar": "https://avatars.githubusercontent.com/u/232434?v=3&s=80",
-    "github": "https://github.com/thmarx",
-    "name": "Thorsten"
-  },
-  {
-    "github_id": "ashertarno",
-    "avatar": "https://avatars.githubusercontent.com/u/2847965?v=3&s=80",
-    "github": "https://github.com/ashertarno",
-    "name": "Asher Tarnopolski",
-    "homepage": "http://il.linkedin.com/in/ashertarnopolski"
-  },
-  {
-    "github_id": "timyates",
-    "avatar": "https://avatars.githubusercontent.com/u/49317?v=3&s=80",
-    "github": "https://github.com/timyates",
-    "name": "Tim Yates",
-    "homepage": "http://twitter.com/tim_yates"
-  },
-  {
-    "github_id": "Zwergal",
-    "avatar": "https://avatars.githubusercontent.com/u/1858670?v=3&s=80",
-    "github": "https://github.com/Zwergal",
-    "name": "Zwergal"
-  },
-  {
-    "github_id": "jorishermans",
-    "avatar": "https://avatars.githubusercontent.com/u/184018?v=3&s=80",
-    "github": "https://github.com/jorishermans",
-    "name": "joris hermans"
-  },
-  {
-    "github_id": "whiteship",
-    "avatar": "https://avatars.githubusercontent.com/u/68532?v=3&s=80",
-    "github": "https://github.com/whiteship",
-    "name": "Keesun Baik",
-    "homepage": "http://whiteship.me"
-  },
-  {
-    "github_id": "keesun",
-    "avatar": "https://avatars.githubusercontent.com/u/463657?v=3&s=80",
-    "github": "https://github.com/keesun",
-    "name": "Keesun Baik (a.k.a, Whiteship)",
-    "homepage": "http://whiteship.me"
-  },
-  {
-    "github_id": "lbovet",
-    "avatar": "https://avatars.githubusercontent.com/u/692124?v=3&s=80",
-    "github": "https://github.com/lbovet",
-    "name": "Laurent Bovet",
-    "homepage": "http://www.ohloh.net/accounts/lbovet"
-  },
-  {
-    "github_id": "marx-espirit",
-    "avatar": "https://avatars.githubusercontent.com/u/2123616?v=3&s=80",
-    "github": "https://github.com/marx-espirit",
-    "name": "marx-espirit"
-  },
-  {
-    "github_id": "jasonparekh",
-    "avatar": "https://avatars.githubusercontent.com/u/475137?v=3&s=80",
-    "github": "https://github.com/jasonparekh",
-    "name": "jasonparekh"
-  },
-  {
-    "github_id": "imavroukakis",
-    "avatar": "https://avatars.githubusercontent.com/u/1764981?v=3&s=80",
-    "github": "https://github.com/imavroukakis",
-    "name": "Ioannis Mavroukakis"
-  },
-  {
-    "github_id": "pidster",
-    "avatar": "https://avatars.githubusercontent.com/u/303151?v=3&s=80",
-    "github": "https://github.com/pidster",
-    "name": "Pid",
-    "homepage": "http://pidster.org"
-  },
-  {
-    "github_id": "karianna",
-    "avatar": "https://avatars.githubusercontent.com/u/180840?v=3&s=80",
-    "github": "https://github.com/karianna",
-    "name": "Martijn Verburg",
-    "homepage": "http://martijnverburg.blogspot.com"
-  },
-  {
-    "github_id": "RichardWarburton",
-    "avatar": "https://avatars.githubusercontent.com/u/328174?v=3&s=80",
-    "github": "https://github.com/RichardWarburton",
-    "name": "Richard Warburton",
-    "homepage": "http://insightfullogic.com"
-  },
-  {
-    "github_id": "danthegoodman",
-    "avatar": "https://avatars.githubusercontent.com/u/110474?v=3&s=80",
-    "github": "https://github.com/danthegoodman",
-    "name": "Danny Kirchmeier"
-  },
-  {
-    "github_id": "whatevercode",
-    "avatar": "https://avatars.githubusercontent.com/u/1756595?v=3&s=80",
-    "github": "https://github.com/whatevercode",
-    "name": "whatevercode"
-  },
-  {
-    "github_id": "kajmagnus79",
-    "avatar": "https://avatars.githubusercontent.com/u/548833?v=3&s=80",
-    "github": "https://github.com/kajmagnus79",
-    "name": "KajMagnus",
-    "homepage": "http://www.debiki.com"
-  },
-  {
-    "github_id": "aschrijver",
-    "avatar": "https://avatars.githubusercontent.com/u/5111931?v=3&s=80",
-    "github": "https://github.com/aschrijver",
-    "name": "Arnold Schrijver"
-  },
-  {
-    "github_id": "Voxelot",
-    "avatar": "https://avatars.githubusercontent.com/u/794823?v=3&s=80",
-    "github": "https://github.com/Voxelot",
-    "name": "Brandon Kite"
-  },
-  {
-    "github_id": "day-me-an",
-    "avatar": "https://avatars.githubusercontent.com/u/2348862?v=3&s=80",
-    "github": "https://github.com/day-me-an",
-    "name": "Damian Wood"
-  },
-  {
-    "github_id": "jyemin",
-    "avatar": "https://avatars.githubusercontent.com/u/1111546?v=3&s=80",
-    "github": "https://github.com/jyemin",
-    "name": "Jeff Yemin"
-  },
-  {
-    "github_id": "mattyb678",
-    "avatar": "https://avatars.githubusercontent.com/u/1524704?v=3&s=80",
-    "github": "https://github.com/mattyb678",
-    "name": "Matt Berteaux"
-  },
-  {
-    "github_id": "zilet",
-    "avatar": "https://avatars.githubusercontent.com/u/1163484?v=3&s=80",
-    "github": "https://github.com/zilet",
-    "name": "Miloš Žikić",
-    "homepage": "http://miloszikic.com"
-  },
-  {
-    "github_id": "jvmvik",
-    "avatar": "https://avatars.githubusercontent.com/u/330204?v=3&s=80",
-    "github": "https://github.com/jvmvik",
-    "name": "Victor Benarbia",
-    "homepage": "http://blog.milkyway.io"
-  },
-  {
-    "github_id": "patoi",
-    "avatar": "https://avatars.githubusercontent.com/u/1846548?v=3&s=80",
-    "github": "https://github.com/patoi",
-    "name": "István Pató",
-    "homepage": "https://twitter.com/patoistvan"
-  },
-  {
-    "github_id": "HugoCrd",
-    "avatar": "https://avatars.githubusercontent.com/u/534015?v=3&s=80",
-    "github": "https://github.com/HugoCrd",
-    "name": "Hugo Cordier",
-    "homepage": "http://www.twitter.com/HugoCrd"
-  },
-  {
-    "github_id": "tigeba",
-    "avatar": "https://avatars.githubusercontent.com/u/1248855?v=3&s=80",
-    "github": "https://github.com/tigeba",
-    "name": "Jonathan wagner",
-    "homepage": "http://www.getbigbang.com"
-  },
-  {
-    "github_id": "ArsenyYankovsky",
-    "avatar": "https://avatars.githubusercontent.com/u/1508345?v=3&s=80",
-    "github": "https://github.com/ArsenyYankovsky",
-    "name": "Arseny Yankovsky"
-  },
-  {
-    "github_id": "OttoAllmendinger",
-    "avatar": "https://avatars.githubusercontent.com/u/283533?v=3&s=80",
-    "github": "https://github.com/OttoAllmendinger",
-    "name": "Otto Allmendinger"
-  },
-  {
-    "github_id": "alkemist",
-    "avatar": "https://avatars.githubusercontent.com/u/17825?v=3&s=80",
-    "github": "https://github.com/alkemist",
-    "name": "Luke Daley",
-    "homepage": "http://ldaley.com"
-  },
-  {
-    "github_id": "tjcrowder",
-    "avatar": "https://avatars.githubusercontent.com/u/27634?v=3&s=80",
-    "github": "https://github.com/tjcrowder",
-    "name": "T.J. Crowder",
-    "homepage": "http://crowdersoftware.com"
-  },
-  {
-    "github_id": "galderz",
-    "avatar": "https://avatars.githubusercontent.com/u/50187?v=3&s=80",
-    "github": "https://github.com/galderz",
-    "name": "Galder Zamarreño",
-    "homepage": "http://zamarreno.com"
-  },
-  {
-    "github_id": "swilliams-pivotal",
-    "avatar": "https://avatars.githubusercontent.com/u/2143017?v=3&s=80",
-    "github": "https://github.com/swilliams-pivotal",
-    "name": "Stuart Williams",
-    "homepage": "http://www.gopivotal.com/"
-  },
-  {
-    "github_id": "edgarchan",
-    "avatar": "https://avatars.githubusercontent.com/u/161952?v=3&s=80",
-    "github": "https://github.com/edgarchan",
-    "name": "Edgar Chan"
-  },
-  {
-    "github_id": "raniejade",
-    "avatar": "https://avatars.githubusercontent.com/u/1041919?v=3&s=80",
-    "github": "https://github.com/raniejade",
-    "name": "Ranie Jade Ramiso",
-    "homepage": "http://polymorphicpanda.io"
-  },
-  {
-    "github_id": "nfmelendez",
-    "avatar": "https://avatars.githubusercontent.com/u/726950?v=3&s=80",
-    "github": "https://github.com/nfmelendez",
-    "name": "Nicolás Melendez",
-    "homepage": "http://www.melendez.com.ar"
-  },
-  {
-    "github_id": "SaschaSchmidt",
-    "avatar": "https://avatars.githubusercontent.com/u/5173378?v=3&s=80",
-    "github": "https://github.com/SaschaSchmidt",
-    "name": "Sascha Schmidt"
-  },
-  {
-    "github_id": "angeloh",
-    "avatar": "https://avatars.githubusercontent.com/u/304674?v=3&s=80",
-    "github": "https://github.com/angeloh",
-    "name": "Angelo H",
-    "homepage": "https://wiredin.io"
-  },
-  {
-    "github_id": "marekjelen",
-    "avatar": "https://avatars.githubusercontent.com/u/156068?v=3&s=80",
-    "github": "https://github.com/marekjelen",
-    "name": "Marek Jelen",
-    "homepage": "http://www.mjelen.eu"
-  },
-  {
-    "github_id": "jdonnerstag",
-    "avatar": "https://avatars.githubusercontent.com/u/366871?v=3&s=80",
-    "github": "https://github.com/jdonnerstag",
-    "name": "Juergen Donnerstag"
-  },
-  {
-    "github_id": "jenslaufer",
-    "avatar": "https://avatars.githubusercontent.com/u/2699798?v=3&s=80",
-    "github": "https://github.com/jenslaufer",
-    "name": "jenslaufer"
-  },
-  {
-    "github_id": "blalor",
-    "avatar": "https://avatars.githubusercontent.com/u/109915?v=3&s=80",
-    "github": "https://github.com/blalor",
-    "name": "Brian Lalor"
-  },
-  {
-    "github_id": "npahucki",
-    "avatar": "https://avatars.githubusercontent.com/u/823555?v=3&s=80",
-    "github": "https://github.com/npahucki",
-    "name": "Nathan Pahucki",
-    "homepage": "http://dataparenting.com"
-  },
-  {
-    "github_id": "figroc",
-    "avatar": "https://avatars.githubusercontent.com/u/2026460?v=3&s=80",
-    "github": "https://github.com/figroc",
-    "name": "figroc"
-  },
   {
     "github_id": "4z3",
     "avatar": "https://avatars.githubusercontent.com/u/427872?v=3&s=80",
@@ -566,195 +15,30 @@ module.exports = { contributors: [
     "homepage": "http://alexboyd.me"
   },
   {
-    "github_id": "jannehietamaki",
-    "avatar": "https://avatars.githubusercontent.com/u/62515?v=3&s=80",
-    "github": "https://github.com/jannehietamaki",
-    "name": "Janne Hietamäki",
-    "homepage": "https://twitter.com/jannehietamaki"
+    "github_id": "abstractj",
+    "avatar": "https://avatars.githubusercontent.com/u/21758?v=3&s=80",
+    "github": "https://github.com/abstractj",
+    "name": "Bruno Oliveira",
+    "homepage": "http://abstractj.org"
   },
   {
-    "github_id": "pmarino90",
-    "avatar": "https://avatars.githubusercontent.com/u/210353?v=3&s=80",
-    "github": "https://github.com/pmarino90",
-    "name": "Paolo Marino"
+    "github_id": "adrianluisgonzalez",
+    "avatar": "https://avatars.githubusercontent.com/u/1521539?v=3&s=80",
+    "github": "https://github.com/adrianluisgonzalez",
+    "name": "Adrian"
   },
   {
-    "github_id": "litch",
-    "avatar": "https://avatars.githubusercontent.com/u/465946?v=3&s=80",
-    "github": "https://github.com/litch",
-    "name": "Justin Litchfield"
+    "github_id": "aesteve",
+    "avatar": "https://avatars.githubusercontent.com/u/1456317?v=3&s=80",
+    "github": "https://github.com/aesteve",
+    "name": "Arnaud Esteve"
   },
   {
-    "github_id": "tazsingh",
-    "avatar": "https://avatars.githubusercontent.com/u/397824?v=3&s=80",
-    "github": "https://github.com/tazsingh",
-    "name": "Tasveer Singh",
-    "homepage": "http://twitter.com/tazsingh"
-  },
-  {
-    "github_id": "fregaham",
-    "avatar": "https://avatars.githubusercontent.com/u/249675?v=3&s=80",
-    "github": "https://github.com/fregaham",
-    "name": "Marek Schmidt",
-    "homepage": "http://www.zemarov.org/~marcho/"
-  },
-  {
-    "github_id": "karfunkel",
-    "avatar": "https://avatars.githubusercontent.com/u/301625?v=3&s=80",
-    "github": "https://github.com/karfunkel",
-    "name": "Alexander (Sascha) Klein"
-  },
-  {
-    "github_id": "zdavep",
-    "avatar": "https://avatars.githubusercontent.com/u/5016400?v=3&s=80",
-    "github": "https://github.com/zdavep",
-    "name": "Dave P",
-    "homepage": "https://twitter.com/zdavep"
-  },
-  {
-    "github_id": "pledbrook",
-    "avatar": "https://avatars.githubusercontent.com/u/19075?v=3&s=80",
-    "github": "https://github.com/pledbrook",
-    "name": "Peter Ledbrook",
-    "homepage": "http://www.cacoethes.co.uk/"
-  },
-  {
-    "github_id": "jkschneider",
-    "avatar": "https://avatars.githubusercontent.com/u/1697736?v=3&s=80",
-    "github": "https://github.com/jkschneider",
-    "name": "Jon Schneider",
-    "homepage": "https://jkschneider.github.io/"
-  },
-  {
-    "github_id": "zeneye",
-    "avatar": "https://avatars.githubusercontent.com/u/1589338?v=3&s=80",
-    "github": "https://github.com/zeneye",
-    "name": "zeneye"
-  },
-  {
-    "github_id": "macedigital",
-    "avatar": "https://avatars.githubusercontent.com/u/248495?v=3&s=80",
-    "github": "https://github.com/macedigital",
-    "name": "Matthias Adler",
-    "homepage": "http://matthiasadler.info"
-  },
-  {
-    "github_id": "jpmeyer",
-    "avatar": "https://avatars.githubusercontent.com/u/3030965?v=3&s=80",
-    "github": "https://github.com/jpmeyer",
-    "name": "John Meyer",
-    "homepage": "http://www.shareaholic.com"
-  },
-  {
-    "github_id": "bedonath",
-    "avatar": "https://avatars.githubusercontent.com/u/5391824?v=3&s=80",
-    "github": "https://github.com/bedonath",
-    "name": "bedonath"
-  },
-  {
-    "github_id": "heryandi",
-    "avatar": "https://avatars.githubusercontent.com/u/412333?v=3&s=80",
-    "github": "https://github.com/heryandi",
-    "name": "heryandi"
-  },
-  {
-    "github_id": "HugoMFernandes",
-    "avatar": "https://avatars.githubusercontent.com/u/6650985?v=3&s=80",
-    "github": "https://github.com/HugoMFernandes",
-    "name": "HugoMFernandes"
-  },
-  {
-    "github_id": "matzew",
-    "avatar": "https://avatars.githubusercontent.com/u/157646?v=3&s=80",
-    "github": "https://github.com/matzew",
-    "name": "Matthias Wessendorf",
-    "homepage": "http://matthiaswessendorf.wordpress.com"
-  },
-  {
-    "github_id": "jstrachan",
-    "avatar": "https://avatars.githubusercontent.com/u/30140?v=3&s=80",
-    "github": "https://github.com/jstrachan",
-    "name": "James Strachan",
-    "homepage": "http://macstrac.blogspot.com/"
-  },
-  {
-    "github_id": "darkredz",
-    "avatar": "https://avatars.githubusercontent.com/u/163544?v=3&s=80",
-    "github": "https://github.com/darkredz",
-    "name": "Leng Sheng Hong",
-    "homepage": "http://doophp.com"
-  },
-  {
-    "github_id": "philidem",
-    "avatar": "https://avatars.githubusercontent.com/u/2395134?v=3&s=80",
-    "github": "https://github.com/philidem",
-    "name": "Phillip Gates-Idem"
-  },
-  {
-    "github_id": "sramki",
-    "avatar": "https://avatars.githubusercontent.com/u/2536113?v=3&s=80",
-    "github": "https://github.com/sramki",
-    "name": "ramki"
-  },
-  {
-    "github_id": "mikaelkaron",
-    "avatar": "https://avatars.githubusercontent.com/u/478468?v=3&s=80",
-    "github": "https://github.com/mikaelkaron",
-    "name": "Mikael Karon",
-    "homepage": "http://mikael.karon.se"
-  },
-  {
-    "github_id": "crazyfrozenpenguin",
-    "avatar": "https://avatars.githubusercontent.com/u/1930528?v=3&s=80",
-    "github": "https://github.com/crazyfrozenpenguin",
-    "name": "crazyfrozenpenguin"
-  },
-  {
-    "github_id": "petermd",
-    "avatar": "https://avatars.githubusercontent.com/u/1470002?v=3&s=80",
-    "github": "https://github.com/petermd",
-    "name": "Peter McDonnell",
-    "homepage": "http://twitter.com/petermd"
-  },
-  {
-    "github_id": "sharathp",
-    "avatar": "https://avatars.githubusercontent.com/u/1427829?v=3&s=80",
-    "github": "https://github.com/sharathp",
-    "name": "Sharath"
-  },
-  {
-    "github_id": "tavisrudd",
-    "avatar": "https://avatars.githubusercontent.com/u/236886?v=3&s=80",
-    "github": "https://github.com/tavisrudd",
-    "name": "Tavis Rudd",
-    "homepage": "http://ca.linkedin.com/in/tavisrudd/"
-  },
-  {
-    "github_id": "mpas",
-    "avatar": "https://avatars.githubusercontent.com/u/139094?v=3&s=80",
-    "github": "https://github.com/mpas",
-    "name": "Marco Pas",
-    "homepage": "http://www.codeverse.org"
-  },
-  {
-    "github_id": "gprasant",
-    "avatar": "https://avatars.githubusercontent.com/u/212911?v=3&s=80",
-    "github": "https://github.com/gprasant",
-    "name": "gprasant"
-  },
-  {
-    "github_id": "jkneb",
-    "avatar": "https://avatars.githubusercontent.com/u/805719?v=3&s=80",
-    "github": "https://github.com/jkneb",
-    "name": "Julien Knebel",
-    "homepage": "http://front-back.com"
-  },
-  {
-    "github_id": "muraken720",
-    "avatar": "https://avatars.githubusercontent.com/u/1238331?v=3&s=80",
-    "github": "https://github.com/muraken720",
-    "name": "Kenichiro Murata",
-    "homepage": "http://qiita.com/muraken720"
+    "github_id": "ahtik",
+    "avatar": "https://avatars.githubusercontent.com/u/140952?v=3&s=80",
+    "github": "https://github.com/ahtik",
+    "name": "Ahti Kitsik",
+    "homepage": "http://ahtik.com"
   },
   {
     "github_id": "akostadinov",
@@ -764,223 +48,24 @@ module.exports = { contributors: [
     "homepage": "http://rboci.blogspot.com/"
   },
   {
-    "github_id": "abstractj",
-    "avatar": "https://avatars.githubusercontent.com/u/21758?v=3&s=80",
-    "github": "https://github.com/abstractj",
-    "name": "Bruno Oliveira",
-    "homepage": "http://abstractj.org"
+    "github_id": "alkemist",
+    "avatar": "https://avatars.githubusercontent.com/u/17825?v=3&s=80",
+    "github": "https://github.com/alkemist",
+    "name": "Luke Daley",
+    "homepage": "http://ldaley.com"
+  },
+  {
+    "github_id": "ALRubinger",
+    "avatar": "https://avatars.githubusercontent.com/u/199891?v=3&s=80",
+    "github": "https://github.com/ALRubinger",
+    "name": "Andrew Lee Rubinger",
+    "homepage": "http://exitcondition.alrubinger.com"
   },
   {
     "github_id": "alwinmark",
     "avatar": "https://avatars.githubusercontent.com/u/2451613?v=3&s=80",
     "github": "https://github.com/alwinmark",
     "name": "alwinmark"
-  },
-  {
-    "github_id": "rce",
-    "avatar": "https://avatars.githubusercontent.com/u/4427896?v=3&s=80",
-    "github": "https://github.com/rce",
-    "name": "Henry Heikkinen",
-    "homepage": "http://rce.fi/"
-  },
-  {
-    "github_id": "johnjelinek",
-    "avatar": "https://avatars.githubusercontent.com/u/873610?v=3&s=80",
-    "github": "https://github.com/johnjelinek",
-    "name": "John Jelinek IV",
-    "homepage": "http://www.tradestation.com"
-  },
-  {
-    "github_id": "jwagenleitner",
-    "avatar": "https://avatars.githubusercontent.com/u/97695?v=3&s=80",
-    "github": "https://github.com/jwagenleitner",
-    "name": "John Wagenleitner"
-  },
-  {
-    "github_id": "rdolgushin",
-    "avatar": "https://avatars.githubusercontent.com/u/1649085?v=3&s=80",
-    "github": "https://github.com/rdolgushin",
-    "name": "Roman Dolgushin"
-  },
-  {
-    "github_id": "sscarduzio",
-    "avatar": "https://avatars.githubusercontent.com/u/1327189?v=3&s=80",
-    "github": "https://github.com/sscarduzio",
-    "name": "Simone Scarduzio"
-  },
-  {
-    "github_id": "zhouyaguo",
-    "avatar": "https://avatars.githubusercontent.com/u/893690?v=3&s=80",
-    "github": "https://github.com/zhouyaguo",
-    "name": "Yaguo Zhou"
-  },
-  {
-    "github_id": "boyvanduuren",
-    "avatar": "https://avatars.githubusercontent.com/u/4145582?v=3&s=80",
-    "github": "https://github.com/boyvanduuren",
-    "name": "Boy van Duuren"
-  },
-  {
-    "github_id": "jhanzair",
-    "avatar": "https://avatars.githubusercontent.com/u/1664454?v=3&s=80",
-    "github": "https://github.com/jhanzair",
-    "name": "jhanzair"
-  },
-  {
-    "github_id": "o3j8",
-    "avatar": "https://avatars.githubusercontent.com/u/6546460?v=3&s=80",
-    "github": "https://github.com/o3j8",
-    "name": "o3j8"
-  },
-  {
-    "github_id": "yerinle",
-    "avatar": "https://avatars.githubusercontent.com/u/499891?v=3&s=80",
-    "github": "https://github.com/yerinle",
-    "name": "Yinka Erinle"
-  },
-  {
-    "github_id": "johnchapin",
-    "avatar": "https://avatars.githubusercontent.com/u/190566?v=3&s=80",
-    "github": "https://github.com/johnchapin",
-    "name": "John Chapin",
-    "homepage": "http://johnchapin.boostrot.net"
-  },
-  {
-    "github_id": "jcrossley3",
-    "avatar": "https://avatars.githubusercontent.com/u/9213?v=3&s=80",
-    "github": "https://github.com/jcrossley3",
-    "name": "Jim Crossley",
-    "homepage": "http://jim.crossleys.org"
-  },
-  {
-    "github_id": "bobmcwhirter",
-    "avatar": "https://avatars.githubusercontent.com/u/15951?v=3&s=80",
-    "github": "https://github.com/bobmcwhirter",
-    "name": "Bob McWhirter",
-    "homepage": "http://projectodd.org/"
-  },
-  {
-    "github_id": "qmx",
-    "avatar": "https://avatars.githubusercontent.com/u/66734?v=3&s=80",
-    "github": "https://github.com/qmx",
-    "name": "Douglas Campos",
-    "homepage": "http://blog.qmx.me"
-  },
-  {
-    "github_id": "sebastienblanc",
-    "avatar": "https://avatars.githubusercontent.com/u/335133?v=3&s=80",
-    "github": "https://github.com/sebastienblanc",
-    "name": "Sebastien Blanc",
-    "homepage": "http://sblanc.org"
-  },
-  {
-    "github_id": "t-beckmann",
-    "avatar": "https://avatars.githubusercontent.com/u/3601625?v=3&s=80",
-    "github": "https://github.com/t-beckmann",
-    "name": "Thomas Beckmann",
-    "homepage": "http://www.mwaysolutions.com"
-  },
-  {
-    "github_id": "sventech",
-    "avatar": "https://avatars.githubusercontent.com/u/972163?v=3&s=80",
-    "github": "https://github.com/sventech",
-    "name": "Sven Pedersen"
-  },
-  {
-    "github_id": "Oleg12",
-    "avatar": "https://avatars.githubusercontent.com/u/4574401?v=3&s=80",
-    "github": "https://github.com/Oleg12",
-    "name": "Oleg"
-  },
-  {
-    "github_id": "WillsJin",
-    "avatar": "https://avatars.githubusercontent.com/u/8045850?v=3&s=80",
-    "github": "https://github.com/WillsJin",
-    "name": "WillsJin"
-  },
-  {
-    "github_id": "bparees",
-    "avatar": "https://avatars.githubusercontent.com/u/4974046?v=3&s=80",
-    "github": "https://github.com/bparees",
-    "name": "Ben Parees",
-    "homepage": "https://www.openshift.com"
-  },
-  {
-    "github_id": "VojtechVitek",
-    "avatar": "https://avatars.githubusercontent.com/u/139342?v=3&s=80",
-    "github": "https://github.com/VojtechVitek",
-    "name": "Vojtech Vitek",
-    "homepage": "http://vojtechvitek.com"
-  },
-  {
-    "github_id": "mgardziejewski",
-    "avatar": "https://avatars.githubusercontent.com/u/12063190?v=3&s=80",
-    "github": "https://github.com/mgardziejewski",
-    "name": "mgardziejewski"
-  },
-  {
-    "github_id": "sfitts",
-    "avatar": "https://avatars.githubusercontent.com/u/1710006?v=3&s=80",
-    "github": "https://github.com/sfitts",
-    "name": "Sean Fitts"
-  },
-  {
-    "github_id": "cdjones32",
-    "avatar": "https://avatars.githubusercontent.com/u/3734174?v=3&s=80",
-    "github": "https://github.com/cdjones32",
-    "name": "Chris Jones"
-  },
-  {
-    "github_id": "zepouet",
-    "avatar": "https://avatars.githubusercontent.com/u/231269?v=3&s=80",
-    "github": "https://github.com/zepouet",
-    "name": "Nicolas ",
-    "homepage": "http://500px.com/zepouet"
-  },
-  {
-    "github_id": "JohnWarnerEF",
-    "avatar": "https://avatars.githubusercontent.com/u/4999710?v=3&s=80",
-    "github": "https://github.com/JohnWarnerEF",
-    "name": "JohnWarnerEF"
-  },
-  {
-    "github_id": "meshuga",
-    "avatar": "https://avatars.githubusercontent.com/u/1073936?v=3&s=80",
-    "github": "https://github.com/meshuga",
-    "name": "Patryk Orwat"
-  },
-  {
-    "github_id": "kromit",
-    "avatar": "https://avatars.githubusercontent.com/u/5220821?v=3&s=80",
-    "github": "https://github.com/kromit",
-    "name": "kromit"
-  },
-  {
-    "github_id": "baldmountain",
-    "avatar": "https://avatars.githubusercontent.com/u/12590?v=3&s=80",
-    "github": "https://github.com/baldmountain",
-    "name": "Geoffrey Clements",
-    "homepage": "http://bald-mountain.blogspot.com"
-  },
-  {
-    "github_id": "igorspasic",
-    "avatar": "https://avatars.githubusercontent.com/u/2280001?v=3&s=80",
-    "github": "https://github.com/igorspasic",
-    "name": "Igor Spasić",
-    "homepage": "http://jodd.org"
-  },
-  {
-    "github_id": "mguillet",
-    "avatar": "https://avatars.githubusercontent.com/u/701325?v=3&s=80",
-    "github": "https://github.com/mguillet",
-    "name": "Michel Guillet",
-    "homepage": "http://www.linkedin.com/in/michelguillet"
-  },
-  {
-    "github_id": "leolux",
-    "avatar": "https://avatars.githubusercontent.com/u/5385814?v=3&s=80",
-    "github": "https://github.com/leolux",
-    "name": "leolux"
   },
   {
     "github_id": "andyhedges",
@@ -990,6 +75,103 @@ module.exports = { contributors: [
     "homepage": "http://blog.hedges.net"
   },
   {
+    "github_id": "angeloh",
+    "avatar": "https://avatars.githubusercontent.com/u/304674?v=3&s=80",
+    "github": "https://github.com/angeloh",
+    "name": "Angelo H",
+    "homepage": "https://wiredin.io"
+  },
+  {
+    "github_id": "apatrida",
+    "avatar": "https://avatars.githubusercontent.com/u/182340?v=3&s=80",
+    "github": "https://github.com/apatrida",
+    "name": "Jayson Minard",
+    "homepage": "https://www.linkedin.com/profile/view?id=68861"
+  },
+  {
+    "github_id": "ArsenyYankovsky",
+    "avatar": "https://avatars.githubusercontent.com/u/1508345?v=3&s=80",
+    "github": "https://github.com/ArsenyYankovsky",
+    "name": "Arseny Yankovsky"
+  },
+  {
+    "github_id": "aschrijver",
+    "avatar": "https://avatars.githubusercontent.com/u/5111931?v=3&s=80",
+    "github": "https://github.com/aschrijver",
+    "name": "Arnold Schrijver"
+  },
+  {
+    "github_id": "ashertarno",
+    "avatar": "https://avatars.githubusercontent.com/u/2847965?v=3&s=80",
+    "github": "https://github.com/ashertarno",
+    "name": "Asher Tarnopolski",
+    "homepage": "http://il.linkedin.com/in/ashertarnopolski"
+  },
+  {
+    "github_id": "baldmountain",
+    "avatar": "https://avatars.githubusercontent.com/u/12590?v=3&s=80",
+    "github": "https://github.com/baldmountain",
+    "name": "Geoffrey Clements",
+    "homepage": "http://yieldbot.com"
+  },
+  {
+    "github_id": "beders",
+    "avatar": "https://avatars.githubusercontent.com/u/522318?v=3&s=80",
+    "github": "https://github.com/beders",
+    "name": "Jochen Bedersdorfer"
+  },
+  {
+    "github_id": "bedonath",
+    "avatar": "https://avatars.githubusercontent.com/u/5391824?v=3&s=80",
+    "github": "https://github.com/bedonath",
+    "name": "bedonath"
+  },
+  {
+    "github_id": "bfx",
+    "avatar": "https://avatars.githubusercontent.com/u/2572196?v=3&s=80",
+    "github": "https://github.com/bfx",
+    "name": "Fabio Bonfante",
+    "homepage": "http://bonfab.io"
+  },
+  {
+    "github_id": "bhowell2",
+    "avatar": "https://avatars.githubusercontent.com/u/3332479?v=3&s=80",
+    "github": "https://github.com/bhowell2",
+    "name": "Blake"
+  },
+  {
+    "github_id": "blackorzar",
+    "avatar": "https://avatars.githubusercontent.com/u/1530107?v=3&s=80",
+    "github": "https://github.com/blackorzar",
+    "name": "blackorzar"
+  },
+  {
+    "github_id": "blalor",
+    "avatar": "https://avatars.githubusercontent.com/u/109915?v=3&s=80",
+    "github": "https://github.com/blalor",
+    "name": "Brian Lalor"
+  },
+  {
+    "github_id": "bobmcwhirter",
+    "avatar": "https://avatars.githubusercontent.com/u/15951?v=3&s=80",
+    "github": "https://github.com/bobmcwhirter",
+    "name": "Bob McWhirter",
+    "homepage": "http://projectodd.org/"
+  },
+  {
+    "github_id": "boyvanduuren",
+    "avatar": "https://avatars.githubusercontent.com/u/4145582?v=3&s=80",
+    "github": "https://github.com/boyvanduuren",
+    "name": "Boy van Duuren"
+  },
+  {
+    "github_id": "bparees",
+    "avatar": "https://avatars.githubusercontent.com/u/4974046?v=3&s=80",
+    "github": "https://github.com/bparees",
+    "name": "Ben Parees",
+    "homepage": "https://www.openshift.com"
+  },
+  {
     "github_id": "brosander",
     "avatar": "https://avatars.githubusercontent.com/u/596137?v=3&s=80",
     "github": "https://github.com/brosander",
@@ -997,73 +179,28 @@ module.exports = { contributors: [
     "homepage": "http://rosander.ninja/"
   },
   {
-    "github_id": "ufoscout",
-    "avatar": "https://avatars.githubusercontent.com/u/960885?v=3&s=80",
-    "github": "https://github.com/ufoscout",
-    "name": "Francesco"
+    "github_id": "bschev",
+    "avatar": "https://avatars.githubusercontent.com/u/10374418?v=3&s=80",
+    "github": "https://github.com/bschev",
+    "name": "Bernadette Schulze Everding"
   },
   {
-    "github_id": "diega",
-    "avatar": "https://avatars.githubusercontent.com/u/79943?v=3&s=80",
-    "github": "https://github.com/diega",
-    "name": "Diego López León",
-    "homepage": "http://locademiaz.wordpress.com"
+    "github_id": "bura",
+    "avatar": "https://avatars.githubusercontent.com/u/1369932?v=3&s=80",
+    "github": "https://github.com/bura",
+    "name": "Andrey Bloschetsov"
   },
   {
-    "github_id": "zigzago",
-    "avatar": "https://avatars.githubusercontent.com/u/603014?v=3&s=80",
-    "github": "https://github.com/zigzago",
-    "name": "zigzago"
+    "github_id": "catandgrep",
+    "avatar": "https://avatars.githubusercontent.com/u/1639457?v=3&s=80",
+    "github": "https://github.com/catandgrep",
+    "name": "Andreas"
   },
   {
-    "github_id": "mstruk",
-    "avatar": "https://avatars.githubusercontent.com/u/213880?v=3&s=80",
-    "github": "https://github.com/mstruk",
-    "name": "Marko Strukelj"
-  },
-  {
-    "github_id": "w0mbat",
-    "avatar": "https://avatars.githubusercontent.com/u/571379?v=3&s=80",
-    "github": "https://github.com/w0mbat",
-    "name": "Daniel Sachse",
-    "homepage": "http://www.wombatsoftware.de"
-  },
-  {
-    "github_id": "rworsnop",
-    "avatar": "https://avatars.githubusercontent.com/u/1618852?v=3&s=80",
-    "github": "https://github.com/rworsnop",
-    "name": "Rob Worsnop"
-  },
-  {
-    "github_id": "fmarinelli",
-    "avatar": "https://avatars.githubusercontent.com/u/790571?v=3&s=80",
-    "github": "https://github.com/fmarinelli",
-    "name": "fmarinelli"
-  },
-  {
-    "github_id": "rajith77",
-    "avatar": "https://avatars.githubusercontent.com/u/1030331?v=3&s=80",
-    "github": "https://github.com/rajith77",
-    "name": "Rajith Muditha Attapattu"
-  },
-  {
-    "github_id": "renatolond",
-    "avatar": "https://avatars.githubusercontent.com/u/173791?v=3&s=80",
-    "github": "https://github.com/renatolond",
-    "name": "Renato \"Lond\" Cerqueira",
-    "homepage": "http://www.lond.com.br"
-  },
-  {
-    "github_id": "sathishk",
-    "avatar": "https://avatars.githubusercontent.com/u/1736813?v=3&s=80",
-    "github": "https://github.com/sathishk",
-    "name": "Sathish Kumar Thiyagarajan"
-  },
-  {
-    "github_id": "blackorzar",
-    "avatar": "https://avatars.githubusercontent.com/u/1530107?v=3&s=80",
-    "github": "https://github.com/blackorzar",
-    "name": "blackorzar"
+    "github_id": "cdjones32",
+    "avatar": "https://avatars.githubusercontent.com/u/3734174?v=3&s=80",
+    "github": "https://github.com/cdjones32",
+    "name": "Chris Jones"
   },
   {
     "github_id": "circlespainter",
@@ -1073,9 +210,1064 @@ module.exports = { contributors: [
     "homepage": "http://dreamtimecircles.com"
   },
   {
+    "github_id": "cjryan",
+    "avatar": "https://avatars.githubusercontent.com/u/3472021?v=3&s=80",
+    "github": "https://github.com/cjryan",
+    "name": "Chris Ryan"
+  },
+  {
+    "github_id": "codesipcoffee",
+    "avatar": "https://avatars.githubusercontent.com/u/7108590?v=3&s=80",
+    "github": "https://github.com/codesipcoffee",
+    "name": "Micah Stevenson"
+  },
+  {
+    "github_id": "coniu",
+    "avatar": "https://avatars.githubusercontent.com/u/3051040?v=3&s=80",
+    "github": "https://github.com/coniu",
+    "name": "coniu"
+  },
+  {
+    "github_id": "CoolBalance",
+    "avatar": "https://avatars.githubusercontent.com/u/2534598?v=3&s=80",
+    "github": "https://github.com/CoolBalance",
+    "name": "Gregory Bruce",
+    "homepage": "http://www.coolbalance.com"
+  },
+  {
+    "github_id": "crazyfrozenpenguin",
+    "avatar": "https://avatars.githubusercontent.com/u/1930528?v=3&s=80",
+    "github": "https://github.com/crazyfrozenpenguin",
+    "name": "crazyfrozenpenguin"
+  },
+  {
+    "github_id": "dankraw",
+    "avatar": "https://avatars.githubusercontent.com/u/2399036?v=3&s=80",
+    "github": "https://github.com/dankraw",
+    "name": "Daniel Krawczyk"
+  },
+  {
+    "github_id": "danthegoodman",
+    "avatar": "https://avatars.githubusercontent.com/u/110474?v=3&s=80",
+    "github": "https://github.com/danthegoodman",
+    "name": "Danny Kirchmeier"
+  },
+  {
+    "github_id": "darkredz",
+    "avatar": "https://avatars.githubusercontent.com/u/163544?v=3&s=80",
+    "github": "https://github.com/darkredz",
+    "name": "Leng Sheng Hong",
+    "homepage": "http://doophp.com"
+  },
+  {
+    "github_id": "darylteo",
+    "avatar": "https://avatars.githubusercontent.com/u/1226920?v=3&s=80",
+    "github": "https://github.com/darylteo",
+    "name": "Daryl Teo",
+    "homepage": "http://darylteo.com"
+  },
+  {
+    "github_id": "day-me-an",
+    "avatar": "https://avatars.githubusercontent.com/u/2348862?v=3&s=80",
+    "github": "https://github.com/day-me-an",
+    "name": "Damian Wood"
+  },
+  {
+    "github_id": "ddossot",
+    "avatar": "https://avatars.githubusercontent.com/u/119028?v=3&s=80",
+    "github": "https://github.com/ddossot",
+    "name": "David Dossot",
+    "homepage": "http://david.dossot.net"
+  },
+  {
+    "github_id": "denisroy",
+    "avatar": "https://avatars.githubusercontent.com/u/2522829?v=3&s=80",
+    "github": "https://github.com/denisroy",
+    "name": "denisroy"
+  },
+  {
+    "github_id": "diabolicallab",
+    "avatar": "https://avatars.githubusercontent.com/u/6454397?v=3&s=80",
+    "github": "https://github.com/diabolicallab",
+    "name": "diabolicallab"
+  },
+  {
+    "github_id": "diega",
+    "avatar": "https://avatars.githubusercontent.com/u/79943?v=3&s=80",
+    "github": "https://github.com/diega",
+    "name": "Diego López León",
+    "homepage": "http://locademiaz.wordpress.com"
+  },
+  {
+    "github_id": "edgarchan",
+    "avatar": "https://avatars.githubusercontent.com/u/161952?v=3&s=80",
+    "github": "https://github.com/edgarchan",
+    "name": "Edgar Chan"
+  },
+  {
+    "github_id": "elad-yosifon",
+    "avatar": "https://avatars.githubusercontent.com/u/2989684?v=3&s=80",
+    "github": "https://github.com/elad-yosifon",
+    "name": "Elad Yosifon"
+  },
+  {
+    "github_id": "figroc",
+    "avatar": "https://avatars.githubusercontent.com/u/2026460?v=3&s=80",
+    "github": "https://github.com/figroc",
+    "name": "figroc"
+  },
+  {
+    "github_id": "fmarinelli",
+    "avatar": "https://avatars.githubusercontent.com/u/790571?v=3&s=80",
+    "github": "https://github.com/fmarinelli",
+    "name": "fmarinelli"
+  },
+  {
+    "github_id": "fmatar",
+    "avatar": "https://avatars.githubusercontent.com/u/111766?v=3&s=80",
+    "github": "https://github.com/fmatar",
+    "name": "Fady Matar"
+  },
+  {
+    "github_id": "fregaham",
+    "avatar": "https://avatars.githubusercontent.com/u/249675?v=3&s=80",
+    "github": "https://github.com/fregaham",
+    "name": "Marek Schmidt",
+    "homepage": "http://www.zemarov.org/~marcho/"
+  },
+  {
+    "github_id": "galderz",
+    "avatar": "https://avatars.githubusercontent.com/u/50187?v=3&s=80",
+    "github": "https://github.com/galderz",
+    "name": "Galder Zamarreño",
+    "homepage": "http://zamarreno.com"
+  },
+  {
+    "github_id": "gaol",
+    "avatar": "https://avatars.githubusercontent.com/u/541437?v=3&s=80",
+    "github": "https://github.com/gaol",
+    "name": "Lin Gao",
+    "homepage": "http://www.ironjacamar.org"
+  },
+  {
+    "github_id": "gitplaneta",
+    "avatar": "https://avatars.githubusercontent.com/u/2615595?v=3&s=80",
+    "github": "https://github.com/gitplaneta",
+    "name": "Radosław Busz",
+    "homepage": "https://twitter.com/radekbusz"
+  },
+  {
+    "github_id": "gprasant",
+    "avatar": "https://avatars.githubusercontent.com/u/212911?v=3&s=80",
+    "github": "https://github.com/gprasant",
+    "name": "gprasant"
+  },
+  {
+    "github_id": "heri333",
+    "avatar": "https://avatars.githubusercontent.com/u/1039538?v=3&s=80",
+    "github": "https://github.com/heri333",
+    "name": "Heribert Hirth"
+  },
+  {
+    "github_id": "heryandi",
+    "avatar": "https://avatars.githubusercontent.com/u/412333?v=3&s=80",
+    "github": "https://github.com/heryandi",
+    "name": "heryandi"
+  },
+  {
+    "github_id": "hgschmie",
+    "avatar": "https://avatars.githubusercontent.com/u/39495?v=3&s=80",
+    "github": "https://github.com/hgschmie",
+    "name": "Henning Schmiedehausen",
+    "homepage": "http://about.me/hgschmie"
+  },
+  {
+    "github_id": "HugoCrd",
+    "avatar": "https://avatars.githubusercontent.com/u/534015?v=3&s=80",
+    "github": "https://github.com/HugoCrd",
+    "name": "Hugo Cordier",
+    "homepage": "http://www.twitter.com/HugoCrd"
+  },
+  {
+    "github_id": "HugoMFernandes",
+    "avatar": "https://avatars.githubusercontent.com/u/6650985?v=3&s=80",
+    "github": "https://github.com/HugoMFernandes",
+    "name": "HugoMFernandes"
+  },
+  {
+    "github_id": "igorspasic",
+    "avatar": "https://avatars.githubusercontent.com/u/2280001?v=3&s=80",
+    "github": "https://github.com/igorspasic",
+    "name": "Igor Spasić",
+    "homepage": "http://jodd.org"
+  },
+  {
+    "github_id": "imavroukakis",
+    "avatar": "https://avatars.githubusercontent.com/u/1764981?v=3&s=80",
+    "github": "https://github.com/imavroukakis",
+    "name": "Ioannis Mavroukakis"
+  },
+  {
+    "github_id": "jannehietamaki",
+    "avatar": "https://avatars.githubusercontent.com/u/62515?v=3&s=80",
+    "github": "https://github.com/jannehietamaki",
+    "name": "Janne Hietamäki",
+    "homepage": "https://twitter.com/jannehietamaki"
+  },
+  {
+    "github_id": "janthony",
+    "avatar": "https://avatars.githubusercontent.com/u/1858839?v=3&s=80",
+    "github": "https://github.com/janthony",
+    "name": "Jerome Anthony",
+    "homepage": "https://www.tumblr.com/blog/cabbagepost"
+  },
+  {
+    "github_id": "jarthorn",
+    "avatar": "https://avatars.githubusercontent.com/u/193877?v=3&s=80",
+    "github": "https://github.com/jarthorn",
+    "name": "John Arthorne"
+  },
+  {
+    "github_id": "jasonparekh",
+    "avatar": "https://avatars.githubusercontent.com/u/475137?v=3&s=80",
+    "github": "https://github.com/jasonparekh",
+    "name": "jasonparekh"
+  },
+  {
+    "github_id": "jbeard6",
+    "avatar": "https://avatars.githubusercontent.com/u/875798?v=3&s=80",
+    "github": "https://github.com/jbeard6",
+    "name": "Joseph Beard",
+    "homepage": "http://www.josephbeard.net"
+  },
+  {
+    "github_id": "jcrossley3",
+    "avatar": "https://avatars.githubusercontent.com/u/9213?v=3&s=80",
+    "github": "https://github.com/jcrossley3",
+    "name": "Jim Crossley",
+    "homepage": "http://jim.crossleys.org"
+  },
+  {
+    "github_id": "jdiazcano",
+    "avatar": "https://avatars.githubusercontent.com/u/1660930?v=3&s=80",
+    "github": "https://github.com/jdiazcano",
+    "name": "Javier"
+  },
+  {
+    "github_id": "jdonnerstag",
+    "avatar": "https://avatars.githubusercontent.com/u/366871?v=3&s=80",
+    "github": "https://github.com/jdonnerstag",
+    "name": "Juergen Donnerstag"
+  },
+  {
+    "github_id": "jenslaufer",
+    "avatar": "https://avatars.githubusercontent.com/u/2699798?v=3&s=80",
+    "github": "https://github.com/jenslaufer",
+    "name": "jenslaufer"
+  },
+  {
+    "github_id": "jhanzair",
+    "avatar": "https://avatars.githubusercontent.com/u/1664454?v=3&s=80",
+    "github": "https://github.com/jhanzair",
+    "name": "jhanzair"
+  },
+  {
+    "github_id": "jkeys089",
+    "avatar": "https://avatars.githubusercontent.com/u/1695857?v=3&s=80",
+    "github": "https://github.com/jkeys089",
+    "name": "jkeys089"
+  },
+  {
+    "github_id": "jkneb",
+    "avatar": "https://avatars.githubusercontent.com/u/805719?v=3&s=80",
+    "github": "https://github.com/jkneb",
+    "name": "Julien Knebel",
+    "homepage": "http://front-back.com"
+  },
+  {
+    "github_id": "jkschneider",
+    "avatar": "https://avatars.githubusercontent.com/u/1697736?v=3&s=80",
+    "github": "https://github.com/jkschneider",
+    "name": "Jon Schneider",
+    "homepage": "https://jkschneider.github.io/"
+  },
+  {
+    "github_id": "johnchapin",
+    "avatar": "https://avatars.githubusercontent.com/u/190566?v=3&s=80",
+    "github": "https://github.com/johnchapin",
+    "name": "John Chapin",
+    "homepage": "http://johnchapin.boostrot.net"
+  },
+  {
+    "github_id": "johnjelinek",
+    "avatar": "https://avatars.githubusercontent.com/u/873610?v=3&s=80",
+    "github": "https://github.com/johnjelinek",
+    "name": "John Jelinek IV",
+    "homepage": "http://www.tradestation.com"
+  },
+  {
+    "github_id": "johnoliver",
+    "avatar": "https://avatars.githubusercontent.com/u/1615532?v=3&s=80",
+    "github": "https://github.com/johnoliver",
+    "name": "John Oliver"
+  },
+  {
+    "github_id": "JohnWarnerEF",
+    "avatar": "https://avatars.githubusercontent.com/u/4999710?v=3&s=80",
+    "github": "https://github.com/JohnWarnerEF",
+    "name": "JohnWarnerEF"
+  },
+  {
+    "github_id": "jorgeuriarte",
+    "avatar": "https://avatars.githubusercontent.com/u/46843?v=3&s=80",
+    "github": "https://github.com/jorgeuriarte",
+    "name": "Jorge Uriarte"
+  },
+  {
+    "github_id": "jorishermans",
+    "avatar": "https://avatars.githubusercontent.com/u/184018?v=3&s=80",
+    "github": "https://github.com/jorishermans",
+    "name": "joris hermans"
+  },
+  {
+    "github_id": "jpmeyer",
+    "avatar": "https://avatars.githubusercontent.com/u/3030965?v=3&s=80",
+    "github": "https://github.com/jpmeyer",
+    "name": "John Meyer",
+    "homepage": "http://www.shareaholic.com"
+  },
+  {
+    "github_id": "jstrachan",
+    "avatar": "https://avatars.githubusercontent.com/u/30140?v=3&s=80",
+    "github": "https://github.com/jstrachan",
+    "name": "James Strachan",
+    "homepage": "http://macstrac.blogspot.com/"
+  },
+  {
+    "github_id": "jtruelove",
+    "avatar": "https://avatars.githubusercontent.com/u/633168?v=3&s=80",
+    "github": "https://github.com/jtruelove",
+    "name": "Jeremy Truelove"
+  },
+  {
     "github_id": "julien3",
     "avatar": "https://avatars.githubusercontent.com/u/2316008?v=3&s=80",
     "github": "https://github.com/julien3",
     "name": "Julien Lehuraux"
+  },
+  {
+    "github_id": "jvmvik",
+    "avatar": "https://avatars.githubusercontent.com/u/330204?v=3&s=80",
+    "github": "https://github.com/jvmvik",
+    "name": "Victor Benarbia",
+    "homepage": "http://blog.milkyway.io"
+  },
+  {
+    "github_id": "jwagenleitner",
+    "avatar": "https://avatars.githubusercontent.com/u/97695?v=3&s=80",
+    "github": "https://github.com/jwagenleitner",
+    "name": "John Wagenleitner"
+  },
+  {
+    "github_id": "jyemin",
+    "avatar": "https://avatars.githubusercontent.com/u/1111546?v=3&s=80",
+    "github": "https://github.com/jyemin",
+    "name": "Jeff Yemin"
+  },
+  {
+    "github_id": "kajmagnus79",
+    "avatar": "https://avatars.githubusercontent.com/u/548833?v=3&s=80",
+    "github": "https://github.com/kajmagnus79",
+    "name": "KajMagnus",
+    "homepage": "http://www.debiki.com"
+  },
+  {
+    "github_id": "kaklakariada",
+    "avatar": "https://avatars.githubusercontent.com/u/4711730?v=3&s=80",
+    "github": "https://github.com/kaklakariada",
+    "name": "kaklakariada"
+  },
+  {
+    "github_id": "karfunkel",
+    "avatar": "https://avatars.githubusercontent.com/u/301625?v=3&s=80",
+    "github": "https://github.com/karfunkel",
+    "name": "Alexander (Sascha) Klein"
+  },
+  {
+    "github_id": "karianna",
+    "avatar": "https://avatars.githubusercontent.com/u/180840?v=3&s=80",
+    "github": "https://github.com/karianna",
+    "name": "Martijn Verburg",
+    "homepage": "http://martijnverburg.blogspot.com"
+  },
+  {
+    "github_id": "keesun",
+    "avatar": "https://avatars.githubusercontent.com/u/463657?v=3&s=80",
+    "github": "https://github.com/keesun",
+    "name": "Keesun Baik (a.k.a, Whiteship)",
+    "homepage": "http://whiteship.me"
+  },
+  {
+    "github_id": "kromit",
+    "avatar": "https://avatars.githubusercontent.com/u/5220821?v=3&s=80",
+    "github": "https://github.com/kromit",
+    "name": "kromit"
+  },
+  {
+    "github_id": "kuujo",
+    "avatar": "https://avatars.githubusercontent.com/u/823318?v=3&s=80",
+    "github": "https://github.com/kuujo",
+    "name": "Jordan Halterman"
+  },
+  {
+    "github_id": "lance",
+    "avatar": "https://avatars.githubusercontent.com/u/15952?v=3&s=80",
+    "github": "https://github.com/lance",
+    "name": "Lance Ball",
+    "homepage": "http://lanceball.com"
+  },
+  {
+    "github_id": "larrytin",
+    "avatar": "https://avatars.githubusercontent.com/u/4640250?v=3&s=80",
+    "github": "https://github.com/larrytin",
+    "name": "田传武"
+  },
+  {
+    "github_id": "LarsTimm",
+    "avatar": "https://avatars.githubusercontent.com/u/12085953?v=3&s=80",
+    "github": "https://github.com/LarsTimm",
+    "name": "Lars Timm"
+  },
+  {
+    "github_id": "lbovet",
+    "avatar": "https://avatars.githubusercontent.com/u/692124?v=3&s=80",
+    "github": "https://github.com/lbovet",
+    "name": "Laurent Bovet",
+    "homepage": "http://www.ohloh.net/accounts/lbovet"
+  },
+  {
+    "github_id": "leolux",
+    "avatar": "https://avatars.githubusercontent.com/u/5385814?v=3&s=80",
+    "github": "https://github.com/leolux",
+    "name": "leolux"
+  },
+  {
+    "github_id": "litch",
+    "avatar": "https://avatars.githubusercontent.com/u/465946?v=3&s=80",
+    "github": "https://github.com/litch",
+    "name": "Justin Litchfield",
+    "homepage": "http://www.superpumpup.com"
+  },
+  {
+    "github_id": "LostInBrittany",
+    "avatar": "https://avatars.githubusercontent.com/u/726476?v=3&s=80",
+    "github": "https://github.com/LostInBrittany",
+    "name": "Horacio Gonzalez",
+    "homepage": "http://lostinbrittany.org"
+  },
+  {
+    "github_id": "macedigital",
+    "avatar": "https://avatars.githubusercontent.com/u/248495?v=3&s=80",
+    "github": "https://github.com/macedigital",
+    "name": "Matthias Adler",
+    "homepage": "http://matthiasadler.info"
+  },
+  {
+    "github_id": "MammatusPlatypus",
+    "avatar": "https://avatars.githubusercontent.com/u/643140?v=3&s=80",
+    "github": "https://github.com/MammatusPlatypus",
+    "name": "MammatusPlatypus"
+  },
+  {
+    "github_id": "manish-panwar",
+    "avatar": "https://avatars.githubusercontent.com/u/5121768?v=3&s=80",
+    "github": "https://github.com/manish-panwar",
+    "name": "manish-panwar"
+  },
+  {
+    "github_id": "marekjelen",
+    "avatar": "https://avatars.githubusercontent.com/u/156068?v=3&s=80",
+    "github": "https://github.com/marekjelen",
+    "name": "Marek Jelen",
+    "homepage": "http://www.mjelen.eu"
+  },
+  {
+    "github_id": "marx-espirit",
+    "avatar": "https://avatars.githubusercontent.com/u/2123616?v=3&s=80",
+    "github": "https://github.com/marx-espirit",
+    "name": "marx-espirit"
+  },
+  {
+    "github_id": "mattyb678",
+    "avatar": "https://avatars.githubusercontent.com/u/1524704?v=3&s=80",
+    "github": "https://github.com/mattyb678",
+    "name": "Matt Berteaux"
+  },
+  {
+    "github_id": "matzew",
+    "avatar": "https://avatars.githubusercontent.com/u/157646?v=3&s=80",
+    "github": "https://github.com/matzew",
+    "name": "Matthias Wessendorf",
+    "homepage": "http://matthiaswessendorf.wordpress.com"
+  },
+  {
+    "github_id": "megesdal",
+    "avatar": "https://avatars.githubusercontent.com/u/772686?v=3&s=80",
+    "github": "https://github.com/megesdal",
+    "name": "Mark Egesdal",
+    "homepage": "http://outsideiq.com"
+  },
+  {
+    "github_id": "meggarr",
+    "avatar": "https://avatars.githubusercontent.com/u/4507985?v=3&s=80",
+    "github": "https://github.com/meggarr",
+    "name": "meggarr"
+  },
+  {
+    "github_id": "meshuga",
+    "avatar": "https://avatars.githubusercontent.com/u/1073936?v=3&s=80",
+    "github": "https://github.com/meshuga",
+    "name": "Patryk Orwat",
+    "homepage": "https://pl.linkedin.com/in/meshuga"
+  },
+  {
+    "github_id": "mgardziejewski",
+    "avatar": "https://avatars.githubusercontent.com/u/12063190?v=3&s=80",
+    "github": "https://github.com/mgardziejewski",
+    "name": "mgardziejewski"
+  },
+  {
+    "github_id": "mguillet",
+    "avatar": "https://avatars.githubusercontent.com/u/701325?v=3&s=80",
+    "github": "https://github.com/mguillet",
+    "name": "Michel Guillet",
+    "homepage": "http://www.linkedin.com/in/michelguillet"
+  },
+  {
+    "github_id": "mikaelkaron",
+    "avatar": "https://avatars.githubusercontent.com/u/478468?v=3&s=80",
+    "github": "https://github.com/mikaelkaron",
+    "name": "Mikael Karon",
+    "homepage": "http://mikael.karon.se"
+  },
+  {
+    "github_id": "mpas",
+    "avatar": "https://avatars.githubusercontent.com/u/139094?v=3&s=80",
+    "github": "https://github.com/mpas",
+    "name": "Marco Pas",
+    "homepage": "http://www.codeverse.org"
+  },
+  {
+    "github_id": "msavy",
+    "avatar": "https://avatars.githubusercontent.com/u/423513?v=3&s=80",
+    "github": "https://github.com/msavy",
+    "name": "Marc Savy"
+  },
+  {
+    "github_id": "mstruk",
+    "avatar": "https://avatars.githubusercontent.com/u/213880?v=3&s=80",
+    "github": "https://github.com/mstruk",
+    "name": "Marko Strukelj"
+  },
+  {
+    "github_id": "muraken720",
+    "avatar": "https://avatars.githubusercontent.com/u/1238331?v=3&s=80",
+    "github": "https://github.com/muraken720",
+    "name": "Kenichiro Murata",
+    "homepage": "http://qiita.com/muraken720"
+  },
+  {
+    "github_id": "Narigo",
+    "avatar": "https://avatars.githubusercontent.com/u/1767865?v=3&s=80",
+    "github": "https://github.com/Narigo",
+    "name": "Joern Bernhardt",
+    "homepage": "http://www.campudus.com/"
+  },
+  {
+    "github_id": "nfmelendez",
+    "avatar": "https://avatars.githubusercontent.com/u/726950?v=3&s=80",
+    "github": "https://github.com/nfmelendez",
+    "name": "Nicolás Melendez",
+    "homepage": "http://www.melendez.com.ar"
+  },
+  {
+    "github_id": "normanmaurer",
+    "avatar": "https://avatars.githubusercontent.com/u/439362?v=3&s=80",
+    "github": "https://github.com/normanmaurer",
+    "name": "Norman Maurer",
+    "homepage": "http://normanmaurer.me"
+  },
+  {
+    "github_id": "npahucki",
+    "avatar": "https://avatars.githubusercontent.com/u/823555?v=3&s=80",
+    "github": "https://github.com/npahucki",
+    "name": "Nathan Pahucki",
+    "homepage": "http://dataparenting.com"
+  },
+  {
+    "github_id": "nscavell",
+    "avatar": "https://avatars.githubusercontent.com/u/447664?v=3&s=80",
+    "github": "https://github.com/nscavell",
+    "name": "Nick Scavelli"
+  },
+  {
+    "github_id": "o3j8",
+    "avatar": "https://avatars.githubusercontent.com/u/6546460?v=3&s=80",
+    "github": "https://github.com/o3j8",
+    "name": "o3j8"
+  },
+  {
+    "github_id": "o7bfg",
+    "avatar": "https://avatars.githubusercontent.com/u/4677880?v=3&s=80",
+    "github": "https://github.com/o7bfg",
+    "name": "o7bfg"
+  },
+  {
+    "github_id": "osmarpixuri",
+    "avatar": "https://avatars.githubusercontent.com/u/1596134?v=3&s=80",
+    "github": "https://github.com/osmarpixuri",
+    "name": "Osmar Cavalcante"
+  },
+  {
+    "github_id": "OttoAllmendinger",
+    "avatar": "https://avatars.githubusercontent.com/u/283533?v=3&s=80",
+    "github": "https://github.com/OttoAllmendinger",
+    "name": "Otto Allmendinger"
+  },
+  {
+    "github_id": "p14n",
+    "avatar": "https://avatars.githubusercontent.com/u/676545?v=3&s=80",
+    "github": "https://github.com/p14n",
+    "name": "Dean Pehrsson-Chapman",
+    "homepage": "http://www.p14n.com"
+  },
+  {
+    "github_id": "patoi",
+    "avatar": "https://avatars.githubusercontent.com/u/1846548?v=3&s=80",
+    "github": "https://github.com/patoi",
+    "name": "István Pató",
+    "homepage": "https://twitter.com/patoistvan"
+  },
+  {
+    "github_id": "pdalpra",
+    "avatar": "https://avatars.githubusercontent.com/u/1514127?v=3&s=80",
+    "github": "https://github.com/pdalpra",
+    "name": "Pierre Dal-Pra"
+  },
+  {
+    "github_id": "petermd",
+    "avatar": "https://avatars.githubusercontent.com/u/1470002?v=3&s=80",
+    "github": "https://github.com/petermd",
+    "name": "Peter McDonnell",
+    "homepage": "http://twitter.com/petermd"
+  },
+  {
+    "github_id": "philidem",
+    "avatar": "https://avatars.githubusercontent.com/u/2395134?v=3&s=80",
+    "github": "https://github.com/philidem",
+    "name": "Phillip Gates-Idem"
+  },
+  {
+    "github_id": "PhilippGrulich",
+    "avatar": "https://avatars.githubusercontent.com/u/1012856?v=3&s=80",
+    "github": "https://github.com/PhilippGrulich",
+    "name": "Philipp ",
+    "homepage": "http://philipp-grulich.de"
+  },
+  {
+    "github_id": "pidster",
+    "avatar": "https://avatars.githubusercontent.com/u/303151?v=3&s=80",
+    "github": "https://github.com/pidster",
+    "name": "Pid",
+    "homepage": "http://pidster.org"
+  },
+  {
+    "github_id": "pledbrook",
+    "avatar": "https://avatars.githubusercontent.com/u/19075?v=3&s=80",
+    "github": "https://github.com/pledbrook",
+    "name": "Peter Ledbrook",
+    "homepage": "http://www.cacoethes.co.uk/"
+  },
+  {
+    "github_id": "pmarino90",
+    "avatar": "https://avatars.githubusercontent.com/u/210353?v=3&s=80",
+    "github": "https://github.com/pmarino90",
+    "name": "Paolo Marino"
+  },
+  {
+    "github_id": "pwielgolaski",
+    "avatar": "https://avatars.githubusercontent.com/u/3696319?v=3&s=80",
+    "github": "https://github.com/pwielgolaski",
+    "name": "Piotr Wielgolaski"
+  },
+  {
+    "github_id": "qmx",
+    "avatar": "https://avatars.githubusercontent.com/u/66734?v=3&s=80",
+    "github": "https://github.com/qmx",
+    "name": "Douglas Campos",
+    "homepage": "http://blog.qmx.me"
+  },
+  {
+    "github_id": "rajith77",
+    "avatar": "https://avatars.githubusercontent.com/u/1030331?v=3&s=80",
+    "github": "https://github.com/rajith77",
+    "name": "Rajith Muditha Attapattu"
+  },
+  {
+    "github_id": "raniejade",
+    "avatar": "https://avatars.githubusercontent.com/u/1041919?v=3&s=80",
+    "github": "https://github.com/raniejade",
+    "name": "Ranie Jade Ramiso",
+    "homepage": "http://polymorphicpanda.io"
+  },
+  {
+    "github_id": "rce",
+    "avatar": "https://avatars.githubusercontent.com/u/4427896?v=3&s=80",
+    "github": "https://github.com/rce",
+    "name": "Henry Heikkinen"
+  },
+  {
+    "github_id": "rdolgushin",
+    "avatar": "https://avatars.githubusercontent.com/u/1649085?v=3&s=80",
+    "github": "https://github.com/rdolgushin",
+    "name": "Roman Dolgushin"
+  },
+  {
+    "github_id": "remi128",
+    "avatar": "https://avatars.githubusercontent.com/u/9085425?v=3&s=80",
+    "github": "https://github.com/remi128",
+    "name": "Michael Remme",
+    "homepage": "http://www.braintags.de"
+  },
+  {
+    "github_id": "renatolond",
+    "avatar": "https://avatars.githubusercontent.com/u/173791?v=3&s=80",
+    "github": "https://github.com/renatolond",
+    "name": "Renato \"Lond\" Cerqueira",
+    "homepage": "http://www.lond.com.br"
+  },
+  {
+    "github_id": "rexorient",
+    "avatar": "https://avatars.githubusercontent.com/u/3493024?v=3&s=80",
+    "github": "https://github.com/rexorient",
+    "name": "rexorient"
+  },
+  {
+    "github_id": "RichardHightower",
+    "avatar": "https://avatars.githubusercontent.com/u/382678?v=3&s=80",
+    "github": "https://github.com/RichardHightower",
+    "name": "Richard Hightower",
+    "homepage": "http://rick-hightower.blogspot.com/"
+  },
+  {
+    "github_id": "RichardWarburton",
+    "avatar": "https://avatars.githubusercontent.com/u/328174?v=3&s=80",
+    "github": "https://github.com/RichardWarburton",
+    "name": "Richard Warburton",
+    "homepage": "http://insightfullogic.com"
+  },
+  {
+    "github_id": "ruslansennov",
+    "avatar": "https://avatars.githubusercontent.com/u/1582377?v=3&s=80",
+    "github": "https://github.com/ruslansennov",
+    "name": "Ruslan Sennov",
+    "homepage": "http://ruslan-sennov.blogspot.com/"
+  },
+  {
+    "github_id": "rworsnop",
+    "avatar": "https://avatars.githubusercontent.com/u/1618852?v=3&s=80",
+    "github": "https://github.com/rworsnop",
+    "name": "Rob Worsnop"
+  },
+  {
+    "github_id": "SaschaSchmidt",
+    "avatar": "https://avatars.githubusercontent.com/u/5173378?v=3&s=80",
+    "github": "https://github.com/SaschaSchmidt",
+    "name": "Sascha Schmidt"
+  },
+  {
+    "github_id": "sathishk",
+    "avatar": "https://avatars.githubusercontent.com/u/1736813?v=3&s=80",
+    "github": "https://github.com/sathishk",
+    "name": "Sathish Kumar Thiyagarajan"
+  },
+  {
+    "github_id": "sebastienblanc",
+    "avatar": "https://avatars.githubusercontent.com/u/335133?v=3&s=80",
+    "github": "https://github.com/sebastienblanc",
+    "name": "Sebastien Blanc",
+    "homepage": "http://sblanc.org"
+  },
+  {
+    "github_id": "sfitts",
+    "avatar": "https://avatars.githubusercontent.com/u/1710006?v=3&s=80",
+    "github": "https://github.com/sfitts",
+    "name": "Sean Fitts"
+  },
+  {
+    "github_id": "sharathp",
+    "avatar": "https://avatars.githubusercontent.com/u/1427829?v=3&s=80",
+    "github": "https://github.com/sharathp",
+    "name": "Sharath"
+  },
+  {
+    "github_id": "shaunrader",
+    "avatar": "https://avatars.githubusercontent.com/u/1207225?v=3&s=80",
+    "github": "https://github.com/shaunrader",
+    "name": "shaunrader"
+  },
+  {
+    "github_id": "sibay",
+    "avatar": "https://avatars.githubusercontent.com/u/12139958?v=3&s=80",
+    "github": "https://github.com/sibay",
+    "name": "Tarek El-Sibay"
+  },
+  {
+    "github_id": "skone",
+    "avatar": "https://avatars.githubusercontent.com/u/878533?v=3&s=80",
+    "github": "https://github.com/skone",
+    "name": "skone"
+  },
+  {
+    "github_id": "spriet2000",
+    "avatar": "https://avatars.githubusercontent.com/u/601885?v=3&s=80",
+    "github": "https://github.com/spriet2000",
+    "name": "spriet2000"
+  },
+  {
+    "github_id": "sramki",
+    "avatar": "https://avatars.githubusercontent.com/u/2536113?v=3&s=80",
+    "github": "https://github.com/sramki",
+    "name": "ramki"
+  },
+  {
+    "github_id": "sscarduzio",
+    "avatar": "https://avatars.githubusercontent.com/u/1327189?v=3&s=80",
+    "github": "https://github.com/sscarduzio",
+    "name": "Simone Scarduzio"
+  },
+  {
+    "github_id": "sventech",
+    "avatar": "https://avatars.githubusercontent.com/u/972163?v=3&s=80",
+    "github": "https://github.com/sventech",
+    "name": "Sven Pedersen",
+    "homepage": "http://linkedin.com/in/sventechie"
+  },
+  {
+    "github_id": "swilliams-pivotal",
+    "avatar": "https://avatars.githubusercontent.com/u/2143017?v=3&s=80",
+    "github": "https://github.com/swilliams-pivotal",
+    "name": "Stuart Williams",
+    "homepage": "http://www.gopivotal.com/"
+  },
+  {
+    "github_id": "t-beckmann",
+    "avatar": "https://avatars.githubusercontent.com/u/3601625?v=3&s=80",
+    "github": "https://github.com/t-beckmann",
+    "name": "Thomas Beckmann",
+    "homepage": "http://www.mwaysolutions.com"
+  },
+  {
+    "github_id": "tavisrudd",
+    "avatar": "https://avatars.githubusercontent.com/u/236886?v=3&s=80",
+    "github": "https://github.com/tavisrudd",
+    "name": "Tavis Rudd",
+    "homepage": "http://ca.linkedin.com/in/tavisrudd/"
+  },
+  {
+    "github_id": "tazsingh",
+    "avatar": "https://avatars.githubusercontent.com/u/397824?v=3&s=80",
+    "github": "https://github.com/tazsingh",
+    "name": "Tasveer Singh",
+    "homepage": "http://twitter.com/tazsingh"
+  },
+  {
+    "github_id": "testn",
+    "avatar": "https://avatars.githubusercontent.com/u/445123?v=3&s=80",
+    "github": "https://github.com/testn",
+    "name": "testn"
+  },
+  {
+    "github_id": "thiagogcm",
+    "avatar": "https://avatars.githubusercontent.com/u/1041364?v=3&s=80",
+    "github": "https://github.com/thiagogcm",
+    "name": "Thiago Moura"
+  },
+  {
+    "github_id": "thmarx",
+    "avatar": "https://avatars.githubusercontent.com/u/232434?v=3&s=80",
+    "github": "https://github.com/thmarx",
+    "name": "Thorsten"
+  },
+  {
+    "github_id": "tigeba",
+    "avatar": "https://avatars.githubusercontent.com/u/1248855?v=3&s=80",
+    "github": "https://github.com/tigeba",
+    "name": "Jonathan wagner",
+    "homepage": "http://www.getbigbang.com"
+  },
+  {
+    "github_id": "timyates",
+    "avatar": "https://avatars.githubusercontent.com/u/49317?v=3&s=80",
+    "github": "https://github.com/timyates",
+    "name": "Tim Yates",
+    "homepage": "http://twitter.com/tim_yates"
+  },
+  {
+    "github_id": "tjcrowder",
+    "avatar": "https://avatars.githubusercontent.com/u/27634?v=3&s=80",
+    "github": "https://github.com/tjcrowder",
+    "name": "T.J. Crowder",
+    "homepage": "http://crowdersoftware.com"
+  },
+  {
+    "github_id": "tobias",
+    "avatar": "https://avatars.githubusercontent.com/u/2631?v=3&s=80",
+    "github": "https://github.com/tobias",
+    "name": "Toby Crawley",
+    "homepage": "http://tcrawley.org/"
+  },
+  {
+    "github_id": "tsegismont",
+    "avatar": "https://avatars.githubusercontent.com/u/1500598?v=3&s=80",
+    "github": "https://github.com/tsegismont",
+    "name": "Thomas Segismont",
+    "homepage": "http://tsegismont.blogspot.fr/"
+  },
+  {
+    "github_id": "ufoscout",
+    "avatar": "https://avatars.githubusercontent.com/u/960885?v=3&s=80",
+    "github": "https://github.com/ufoscout",
+    "name": "Francesco"
+  },
+  {
+    "github_id": "VitorFreitas",
+    "avatar": "https://avatars.githubusercontent.com/u/860053?v=3&s=80",
+    "github": "https://github.com/VitorFreitas",
+    "name": "Vitor Barbosa de Freitas",
+    "homepage": "http://vtrbtf.com"
+  },
+  {
+    "github_id": "VojtechVitek",
+    "avatar": "https://avatars.githubusercontent.com/u/139342?v=3&s=80",
+    "github": "https://github.com/VojtechVitek",
+    "name": "Vojtech Vitek",
+    "homepage": "http://vojtechvitek.com"
+  },
+  {
+    "github_id": "Voxelot",
+    "avatar": "https://avatars.githubusercontent.com/u/794823?v=3&s=80",
+    "github": "https://github.com/Voxelot",
+    "name": "Brandon Kite"
+  },
+  {
+    "github_id": "w0mbat",
+    "avatar": "https://avatars.githubusercontent.com/u/571379?v=3&s=80",
+    "github": "https://github.com/w0mbat",
+    "name": "Daniel Sachse",
+    "homepage": "http://www.wombatsoftware.de"
+  },
+  {
+    "github_id": "whatevercode",
+    "avatar": "https://avatars.githubusercontent.com/u/1756595?v=3&s=80",
+    "github": "https://github.com/whatevercode",
+    "name": "whatevercode"
+  },
+  {
+    "github_id": "whiteship",
+    "avatar": "https://avatars.githubusercontent.com/u/68532?v=3&s=80",
+    "github": "https://github.com/whiteship",
+    "name": "Keesun Baik",
+    "homepage": "http://whiteship.me"
+  },
+  {
+    "github_id": "WillsJin",
+    "avatar": "https://avatars.githubusercontent.com/u/8045850?v=3&s=80",
+    "github": "https://github.com/WillsJin",
+    "name": "WillsJin"
+  },
+  {
+    "github_id": "woorea",
+    "avatar": "https://avatars.githubusercontent.com/u/557521?v=3&s=80",
+    "github": "https://github.com/woorea",
+    "name": "Luis Gervaso",
+    "homepage": "http://woorea.github.com"
+  },
+  {
+    "github_id": "wprice",
+    "avatar": "https://avatars.githubusercontent.com/u/467370?v=3&s=80",
+    "github": "https://github.com/wprice",
+    "name": "Weston M. Price",
+    "homepage": "http://www.redhat.com/en"
+  },
+  {
+    "github_id": "wrobelm",
+    "avatar": "https://avatars.githubusercontent.com/u/7239170?v=3&s=80",
+    "github": "https://github.com/wrobelm",
+    "name": "wrobelm"
+  },
+  {
+    "github_id": "yerinle",
+    "avatar": "https://avatars.githubusercontent.com/u/499891?v=3&s=80",
+    "github": "https://github.com/yerinle",
+    "name": "Yinka Erinle"
+  },
+  {
+    "github_id": "zaytsev",
+    "avatar": "https://avatars.githubusercontent.com/u/182761?v=3&s=80",
+    "github": "https://github.com/zaytsev",
+    "name": "Sergey Zaytsev"
+  },
+  {
+    "github_id": "zdanek",
+    "avatar": "https://avatars.githubusercontent.com/u/440614?v=3&s=80",
+    "github": "https://github.com/zdanek",
+    "name": "Bartek Zdanowski",
+    "homepage": "http://bartekzdanowski.blogspot.com/"
+  },
+  {
+    "github_id": "zdavep",
+    "avatar": "https://avatars.githubusercontent.com/u/5016400?v=3&s=80",
+    "github": "https://github.com/zdavep",
+    "name": "Dave P",
+    "homepage": "https://twitter.com/zdavep"
+  },
+  {
+    "github_id": "zeneye",
+    "avatar": "https://avatars.githubusercontent.com/u/1589338?v=3&s=80",
+    "github": "https://github.com/zeneye",
+    "name": "zeneye"
+  },
+  {
+    "github_id": "zepouet",
+    "avatar": "https://avatars.githubusercontent.com/u/231269?v=3&s=80",
+    "github": "https://github.com/zepouet",
+    "name": "Nicolas ",
+    "homepage": "http://500px.com/zepouet"
+  },
+  {
+    "github_id": "zhouyaguo",
+    "avatar": "https://avatars.githubusercontent.com/u/893690?v=3&s=80",
+    "github": "https://github.com/zhouyaguo",
+    "name": "Yaguo Zhou"
+  },
+  {
+    "github_id": "zigzago",
+    "avatar": "https://avatars.githubusercontent.com/u/603014?v=3&s=80",
+    "github": "https://github.com/zigzago",
+    "name": "zigzago"
+  },
+  {
+    "github_id": "zilet",
+    "avatar": "https://avatars.githubusercontent.com/u/1163484?v=3&s=80",
+    "github": "https://github.com/zilet",
+    "name": "Miloš Žikić",
+    "homepage": "http://miloszikic.com"
+  },
+  {
+    "github_id": "Zwergal",
+    "avatar": "https://avatars.githubusercontent.com/u/1858670?v=3&s=80",
+    "github": "https://github.com/Zwergal",
+    "name": "Zwergal"
   }
 ] };

--- a/src/main/tasks/update-contributors.js
+++ b/src/main/tasks/update-contributors.js
@@ -271,6 +271,8 @@ module.exports = function(client_id, client_secret, current_contributors) {
       return;
     }
 
+    contributors.sort(function(a, b){return a['github_id'].localeCompare(b['github_id'])});
+
     // write contributors to output stream
     var file = new gutil.File({
       path: "contributors-gen.js",


### PR DESCRIPTION
After I tried regenerating the contributor list, there were a few changes due to user entries shifting to a different place in the list, probably since some contributed to additional repos. I decided it is a good idea to sort the list by githubid to have a consistent order.
