### PR TITLE
Remove extra "V" typo

### DIFF
--- a/src/main/asciidoc-override/vertx-web/ceylon/index.adoc
+++ b/src/main/asciidoc-override/vertx-web/ceylon/index.adoc
@@ -9,7 +9,7 @@ modern, scalable, web apps.
 Vert.x core provides a fairly low level set of functionality for handling HTTP, and for some applications
 that will be sufficient.
 
-VVert.x-Web builds on Vert.x core to provide a richer set of functionality for building real web applications, more
+Vert.x-Web builds on Vert.x core to provide a richer set of functionality for building real web applications, more
 easily.
 
 It's the successor to http://pmlopes.github.io/yoke/[Yoke] in Vert.x 2.x, and takes inspiration from projects such

--- a/src/main/asciidoc-override/vertx-web/groovy/index.adoc
+++ b/src/main/asciidoc-override/vertx-web/groovy/index.adoc
@@ -9,7 +9,7 @@ modern, scalable, web apps.
 Vert.x core provides a fairly low level set of functionality for handling HTTP, and for some applications
 that will be sufficient.
 
-VVert.x-Web builds on Vert.x core to provide a richer set of functionality for building real web applications, more
+Vert.x-Web builds on Vert.x core to provide a richer set of functionality for building real web applications, more
 easily.
 
 It's the successor to http://pmlopes.github.io/yoke/[Yoke] in Vert.x 2.x, and takes inspiration from projects such

--- a/src/main/asciidoc-override/vertx-web/java/index.adoc
+++ b/src/main/asciidoc-override/vertx-web/java/index.adoc
@@ -9,7 +9,7 @@ modern, scalable, web apps.
 Vert.x core provides a fairly low level set of functionality for handling HTTP, and for some applications
 that will be sufficient.
 
-VVert.x-Web builds on Vert.x core to provide a richer set of functionality for building real web applications, more
+Vert.x-Web builds on Vert.x core to provide a richer set of functionality for building real web applications, more
 easily.
 
 It's the successor to http://pmlopes.github.io/yoke/[Yoke] in Vert.x 2.x, and takes inspiration from projects such

--- a/src/main/asciidoc-override/vertx-web/js/index.adoc
+++ b/src/main/asciidoc-override/vertx-web/js/index.adoc
@@ -9,7 +9,7 @@ modern, scalable, web apps.
 Vert.x core provides a fairly low level set of functionality for handling HTTP, and for some applications
 that will be sufficient.
 
-VVert.x-Web builds on Vert.x core to provide a richer set of functionality for building real web applications, more
+Vert.x-Web builds on Vert.x core to provide a richer set of functionality for building real web applications, more
 easily.
 
 It's the successor to http://pmlopes.github.io/yoke/[Yoke] in Vert.x 2.x, and takes inspiration from projects such

--- a/src/main/asciidoc-override/vertx-web/ruby/index.adoc
+++ b/src/main/asciidoc-override/vertx-web/ruby/index.adoc
@@ -9,7 +9,7 @@ modern, scalable, web apps.
 Vert.x core provides a fairly low level set of functionality for handling HTTP, and for some applications
 that will be sufficient.
 
-VVert.x-Web builds on Vert.x core to provide a richer set of functionality for building real web applications, more
+Vert.x-Web builds on Vert.x core to provide a richer set of functionality for building real web applications, more
 easily.
 
 It's the successor to http://pmlopes.github.io/yoke/[Yoke] in Vert.x 2.x, and takes inspiration from projects such


### PR DESCRIPTION
Correct "VVert.x" to "Vert.x" in Vert.x-Web documentation.