### PR TITLE
Typo fixes for 2017-02-09-vertx-3.4.0.beta1.md

### DIFF
--- a/src/site/blog/posts/2017-02-09-vertx-3.4.0.beta1.md
+++ b/src/site/blog/posts/2017-02-09-vertx-3.4.0.beta1.md
@@ -7,7 +7,7 @@ author: vietj
 
 ## TL;DR
 
-we have released 3.4.0.Beta1, this release is the biggest since Vert.x 3.0.0 with plenty of great futures.
+we have released 3.4.0.Beta1, this release is the biggest since Vert.x 3.0.0 with plenty of great features.
 
 You can use consume it in your projects from Maven or Gradle as usual with the version `3.4.0.Beta1` or read
 
@@ -19,9 +19,9 @@ Let me outline the important changes you can already find in this Beta1.
 
 ## Vert.x Web Client
 
-in a simple sentence "Vert.x Web Client is to Vert.x HttpClient what Vert.x Web is to HttpServer”
+In a simple sentence "Vert.x Web Client is to Vert.x HttpClient what Vert.x Web is to HttpServer”
 
-The Web Client makes easy to do HTTP request/response interactions with a web server, and provides advanced features like:
+The Web Client makes it easy to do HTTP request/response interactions with a web server, and provides advanced features like:
 
 - Json body encoding / decoding
 - request/response pumping
@@ -121,17 +121,17 @@ Server started on 8080
 Succeeded in deploying verticle
 ```
 
-As you can see, Kotlin is using directly the Java API and we thought that it might be a cool thing to do the
+As you can see, Kotlin is using the Java API directly, and we thought that it might be a cool thing to do the
 same with Groovy support. So we have reconsidered our Groovy support and now it uses the plain Java API,
-without loosing the existing features.
+without losing the existing features.
 
-Thanks to Groovy extension methods, idiomatic Groovy it still supporting while benefiting of the full Java API!
+Thanks to Groovy extension methods, idiomatic Groovy is still supported while benefiting from the full Java API!
 
 Scala support is also planned for 3.4.0 and will be released soon, watch [@vertx_project](https://twitter.com/vertx_project).
 
 ## The microservices story goes on...
 
-Our API have matured and now they have been moved out of tech preview, of course this wasn't enough and we now
+Our APIs have matured and now they have been moved out of tech preview, of course this wasn't enough and we now
 have _Vert.x Config_, an extensible way to configure Vert.x applications supporting File, json, ENV, system properties,
 HTTP, _Kubernetes Configmap_, _Consul_, _Spring Config Server_, _Redis_, _Git_, _Zookeeper_, ... stores as well as
 several formats: properties file, YAML and Hocon.
@@ -212,7 +212,7 @@ server.listen(ar -> {
 
 ## Vert.x SQL streaming
 
-We now supports streaming style for SQL queries:
+We now support streaming style for SQL queries:
 
 ```
 connection.queryStream("select * from test", stream -> {
@@ -255,18 +255,18 @@ client
 
 ## Finally
 
-In addition of all these brillants features here is a list of more-than-noticeable things you have in this Beta1:
+In addition to all these brillant features here is a list of more-than-noticeable things you have in this Beta1:
 
 - Vert.x Infinispan replaces Vert.x Jgroups cluster manager
 - Vert.x Consul Client provides a full fledged client for Consul
 - Oauth2 predefined configuration with 16 settings from _Azure Active Directory_, to _Twitter_ with the usual suspects (_Facebook_, _LinkedIn_, ...)
 - Http client now follow redirects
 
-You can use consume it in your projects from Maven or Gradle as usual with the version `3.4.0.Beta1` or read
+You can use and consume it in your projects from Maven or Gradle as usual with the version `3.4.0.Beta1` or read
 
  - the [documentation preview](http://vertx.io/docs/3.4.0.Beta1/)
  - the [release notes](https://gist.github.com/vietj/1ce63b368af127775512afbfc0ab14cc)
  - see the [actual examples](https://github.com/vert-x3/vertx-examples/tree/3.4.0-SNAPSHOT)
 
-Last but not least, I want to personally thank all the persons that contributed to this release, beyond the Vert.x core team, the actual
- Vert.x committers and many other persons have brought a lot of efforts in this upcoming 3.4.0!!!!
+Last but not least, I want to personally thank all the people that contributed to this release, beyond the Vert.x core team, the actual
+ Vert.x committers and many other people who have given a lot of effort to this upcoming 3.4.0!!!!


### PR DESCRIPTION
Some small typo fixes for 3.4.0.beta1 blog `2017-02-09-vertx-3.4.0.beta1.md`.