### PR TITLE
correct double quotes in source code examples

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -116,8 +116,8 @@ class Server extends ScalaVerticle {
     vertx
       .createHttpServer()
      .requestHandler(_.response()
-       .putHeader(“content-type”, “text/plain”)
-       .end(“Hello from Vert.x”))
+       .putHeader("content-type", "text/plain")
+       .end("Hello from Vert.x"))
      .listen(8080)
   }
 }}</code></pre>
@@ -131,8 +131,8 @@ class Server : AbstractVerticle() {
     vertx.createHttpServer()
       .requestHandler { req ->
         req.response()
-          .putHeader(“content-type”, “text/plain”)
-          .end("Hello from Vert.x”)
+          .putHeader("content-type", "text/plain")
+          .end("Hello from Vert.x")
         }
       .listen(8080)
   }


### PR DESCRIPTION
I saw the code highlighting was off on http://vertx.io/ . I didn't actually test the examples.