### PR TITLE
Fixed Kotlin example formatting on main page

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -133,8 +133,7 @@ class Server : AbstractVerticle() {
         req.response()
           .putHeader("content-type", "text/plain")
           .end("Hello from Vert.x")
-        }
-      .listen(8080)
+      }.listen(8080)
   }
 }</code></pre>
           </div>


### PR DESCRIPTION
Same formatting style that used for other examples on the same page