### PR TITLE
Added links for parts 5 and 6 in the intro blogs

### DIFF
--- a/src/site/blog/posts/intro-series/2015-08-03-post-04-unit-and-integration-tests.md
+++ b/src/site/blog/posts/intro-series/2015-08-03-post-04-unit-and-integration-tests.md
@@ -492,6 +492,6 @@ mvn clean verify
 
 Wow, what a trip ! We are done... In this post we have seen how we can gain confidence in Vert.x applications by implementing both unit and integration tests. Unit tests, thanks to vert.x unit, are able to check the asynchronous aspect of Vert.x application, but could be complex for large scenarios. Thanks to Rest Assured and AssertJ, integration tests are dead simple to write... but the setup is not straightforward. This post have shown how it can be configured easily. Obviously, you could also use AssertJ and Rest Assured in your unit tests.
 
-Next time, we are going to replace the _in memory_ backend with a database, and use asynchronous integration with this database.
+In the [next post](http://vertx.io/blog/using-the-asynchronous-sql-client/), we replace the _in memory_ backend with a database, and use asynchronous integration with this database.
 
 Stay Tuned & Happy Coding !

--- a/src/site/blog/posts/intro-series/2015-10-19-post-05-using-the-asynchronous-sql-client.md
+++ b/src/site/blog/posts/intro-series/2015-10-19-post-05-using-the-asynchronous-sql-client.md
@@ -300,6 +300,6 @@ Open your browser to `http://localhost:8082/assets/index.html`, and you should s
 
 In this post, we saw how you can use JDBC database with vert.x, and thus without too much burden. You may have been surprised by the asynchronous development model, but once you start using it, it's hard to come back.
 
-Next time, let's see how the same application can use mongoDB instead of HSQL.
+In the [next post](http://vertx.io/blog/combine-vert-x-and-mongo-to-build-a-giant/), we see how the same application can use mongoDB instead of HSQL.
 
 Stay tuned, and happy coding !


### PR DESCRIPTION
Currently the 'intro to' blog series doesn't include links to part 5 and 6, making one think that part 4 is the end. I've just added links in the bottom from 4->5 and 5->6.

Apologies for the extraneous merge included in this commit. I made two changes through the Github website and it created two different branches.

(Also, do changes committed here directly affect the main website?)