### PR TITLE
Doc update: Hazelcast is the default cluster manager in the CLI

### DIFF
--- a/src/site/docs/index.html
+++ b/src/site/docs/index.html
@@ -1717,7 +1717,7 @@ sidebar: true
                     <div class="row">
                         <div class="col-md-6">
                             <h4 id="hazelcast">Hazelcast</h4>
-                            <p>Cluster manager implementation that uses Hazelcast. This is the default.</p>
+                            <p>Cluster manager implementation that uses Hazelcast. This is the default in the <a href="{{ site_url }}docs/vertx-core/java/#_the_vertx_command_line">'vertx' command line</a>.</p>
                             <ul class="list-unstyled">
                                 <li><a href="https://github.com/vert-x3/vertx-hazelcast">Source</a></li>
                                 <li><a href="{{ site_url }}docs/vertx-hazelcast/java">Manual</a></li>


### PR DESCRIPTION
Avoid confusion with what "default" cluster manager means.