### PR TITLE
Update of guide-for-java-devs date

### DIFF
--- a/src/main/materials/materials.js
+++ b/src/main/materials/materials.js
@@ -11,7 +11,7 @@ var books = [
     title: "A gentle guide to asynchronous programming with Eclipse Vert.x for Java developers",
     author: "Julien Ponge, Thomas Segismont and Julien Viet",
     link: "/docs/guide-for-java-devs",
-    date: "19/10/2017"
+    date: "14/02/2018"
   }
 ];
 


### PR DESCRIPTION
Version 1.2.0 of this great material was published on 14th of Feb, 2018.