### PR TITLE
Vscode Vertx Starter blog post

### DIFF
--- a/src/site/blog/posts/releases/2019-05-27-vertx-3.7.1-release.md
+++ b/src/site/blog/posts/releases/2019-05-27-vertx-3.7.1-release.md
@@ -128,6 +128,7 @@ The next version of Vert.x will be 3.8 and targets end of June / early July with
 completed and `Future` is a view that is consumed by clients
 - Json Pointer support
 - The new SQL client will be released as tech preview (until v4)
+- RedisPool as tech preview (until v4) bring back connection management, lazy reconnect and scaling to all client modes (Single, Sentinel and Cluster)
 
 Vert.x 3.7.1 release notes
 

--- a/src/site/blog/posts/releases/2019-05-31-vscode-vertx-starter.md
+++ b/src/site/blog/posts/releases/2019-05-31-vscode-vertx-starter.md
@@ -1,0 +1,27 @@
+---
+title: VS Code Vert.x Starter Extension
+date: 2019-05-31
+template: post.html
+author: danielpetisme
+draft: false
+---
+
+Hi Vert.x community! Today, we are really excited to announce the [Visual Studio Code Vert.x Starter](https://marketplace.visualstudio.com/items?itemName=danielpetisme.vscode-vertx-starter) extension.
+
+The extension is a community contribution made by [Daniel Petisme (@danielpetisme)](https://twitter.com/danielpetisme).
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/R3ZbQ_5Jf4M" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+[Visual Studio Code](https://code.visualstudio.com/) is a popular code editor with a lot of additional extensions.
+
+[Visual Studio Code Vert.x Starter](https://marketplace.visualstudio.com/items?itemName=danielpetisme.vscode-vertx-starter) extension allows your to:
+- Create a Vert.x project
+- Customize the creation (Vert.x version, language, build tool, `groupId`, `artifactId`, package name, JDK version)
+- Search for dependencies
+
+The extension can be configured to match your context (e.g. defining your default company `groupId`).
+
+Behind the scene, the extension relies on the Vert.x application generator API and demonstrate how easy it is to develop your own IDE plugin or custom tooling to generate Vert.x projects.
+For further details about the [start.vertx.io](https://start.vertx.io) API, please refer to the [Vert.x Starter project on GitHub](https://github.com/vert-x3/vertx-starter).
+
+Feel free to ask questions or propose new features on the [VSCode Vert.x Starter GitHub repository](https://github.com/danielpetisme/vscode-vertx-starter).


### PR DESCRIPTION
As discussed a blog post to announce Visual Studio Code Extension.

The extension is already published on the marketplace so the date of publication doesn't matter (I saw the 3.7.1 realease for 27/05, I think the publications shouldn't be on the same period.

The extension
https://marketplace.visualstudio.com/items?itemName=danielpetisme.vscode-vertx-starter