### PR TITLE
Use v1.5.0 of the guide

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>com.github.vert-x3</groupId>
       <artifactId>vertx-guide-for-java-devs</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.0</version>
       <classifier>docs</classifier>
       <type>zip</type>
     </dependency>


### PR DESCRIPTION
The guide has been synchronized with the API changes for Vert.x 3.8.0.

For v4 we should rework the guide in a simpler way, and use the new SQL clients, etc.