### PR TITLE
Fix 3.8.5 release in homepage and download page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>vertx-web-site</artifactId>
-  <version>3.8.4</version>
+  <version>3.8.5</version>
 
   <name>Vert.x Website</name>
 
@@ -57,9 +57,9 @@
   </licenses>
 
   <properties>
-    <vertx.version>3.8.4</vertx.version>
-    <vertx.download.version>3.8.4</vertx.download.version>
-    <vertx.docs.version>3.8.4</vertx.docs.version>
+    <vertx.version>3.8.5</vertx.version>
+    <vertx.download.version>3.8.5</vertx.download.version>
+    <vertx.docs.version>3.8.5</vertx.docs.version>
 
     <asciidoclet.version>1.5.1</asciidoclet.version>
     <apacheds-protocol-dns.version>1.5.7</apacheds-protocol-dns.version>


### PR DESCRIPTION
Motivation:

[Vert.x homepage](https://vertx.io/) and [download page](https://vertx.io/download/) still shows `3.8.4`, but `3.8.5` has been released several days ago. I believe that the docs are not updated as well.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
